### PR TITLE
Add Vanta interview prep (phone screen + onsite reference)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 **/.vscode
 **/__pycache__/
 *.pyc
+.gstack/

--- a/company-tags/vanta/.gitignore
+++ b/company-tags/vanta/.gitignore
@@ -1,0 +1,5 @@
+# Compiled binary from task_dependency.cpp
+/task_dependency
+
+# Generated study PDFs
+*.pdf

--- a/company-tags/vanta/README.md
+++ b/company-tags/vanta/README.md
@@ -1,0 +1,35 @@
+# Vanta — Interview Prep
+
+Vanta is a compliance automation platform (SOC 2, ISO 27001, HIPAA, GDPR). Their engineering interview loop, based on candidate reports from 1point3acres (June 2025 – June 2026):
+
+| Stage | Format | What they test |
+|---|---|---|
+| **Phone screen** | 60 min, CoderPad (sometimes local Python) | Working code on 2 practical problems (see [`phone-screen.md`](./phone-screen.md)) |
+| Onsite Round 1 | Coding — practical | Same problem *family* as phone screen; may involve reading from a file |
+| Onsite Round 2 | System design | **DAU/MAU tracking system** — event ingestion → aggregation → query |
+| Onsite Round 3 | "Principle" (scenario behavioral) | Hypothetical scenarios, not standard STAR. Bring stories anyway. |
+| Onsite Round 4 | HM / Project deep-dive | Ownership, scope, cross-functional impact |
+| Onsite Round 5 | AI technical deep-dive | Design a RAG pipeline (compliance-doc flavored) |
+
+## Priority for Ben's phone screen
+
+1. **Task Dependency** — 5+ reports. Both Q1 (deps of targets) and Q2 (ancestors). Solve cleanly in <30 min combined.
+2. **Employee Training / Group aggregation** — backup problem, also reported multiple times.
+3. **Time management** — don't get stuck debugging Q1; move on and come back.
+4. **Environment** — Ben's screen is CoderPad (confirmed), but keep a local Python env ready in case they switch.
+
+## Files
+
+- [`phone-screen.md`](./phone-screen.md) — strategy, format notes, links to both problems.
+- [`task_dependency.py`](./task_dependency.py) — reference solution for Q1 + Q2. Runnable.
+- [`task_dependency_test.py`](./task_dependency_test.py) — test cases mirroring reported variants.
+- [`employee_training.py`](./employee_training.py) — reference solution.
+- [`employee_training_test.py`](./employee_training_test.py) — test cases.
+- [`onsite/`](./onsite/) — one file per onsite round.
+
+## How to drill
+
+- 25-min timer per problem, cold start. Solve in a scratch file, then diff against the reference.
+- Verbalize as you code — the interviewer is quiet by report; you drive the discussion.
+- If stuck at 10 min: state your current thinking out loud. Interviewers grade communication as much as code.
+- After the drill: read the "common bug" section in the problem file to catch what you'd have missed.

--- a/company-tags/vanta/employee_training.py
+++ b/company-tags/vanta/employee_training.py
@@ -4,100 +4,103 @@ Vanta phone screen (backup problem): Employee Security Training & Group Aggregat
 Q1: Given an Employee (start_day, training_days_required) and a check_day,
     is the employee compliant? If not, how many days overdue?
 
-    An employee's training is due on day `start_day + training_days_required`.
+    Due day = start_day + training_days_required.
     Convention (CLARIFY with interviewer):
-      - If check_day <= start_day + training_days_required → compliant, overdue = 0.
-      - Else → overdue = check_day - (start_day + training_days_required).
+      - check_day <= due_day → compliant, overdue = 0.
+      - check_day  > due_day → overdue = check_day - due_day.
 
-Q2: Employees live in a TREE of groups. For every group in the tree, compute:
-      - total_employees:   count of employees in this group's subtree
-      - total_overdue_days: sum of overdue days across all those employees
-                            (as of a given check_day)
+Q2: Employees live in a TREE (or forest) of groups. For every group, compute:
+      - total_employees:  count of employees in this group's subtree
+      - total_overdue:    sum of overdue days across those employees
+                          (as of a given check_day)
 
-    Do it in one DFS — O(V + total_employees).
+    Done in a single DFS.
 
-Assumptions to CLARIFY:
-    - Is the group tree guaranteed connected / single root? (Handle forest below.)
-    - Are training-not-yet-started employees compliant? (Yes here.)
-    - Boundary: employee due on check_day itself — compliant? (Yes here.)
+Assumptions to CLARIFY with the interviewer:
+    - Group graph is a tree/forest (no cycles, no shared subtrees).
+    - Not-yet-started employees (check_day < start_day) are compliant.
+    - Boundary: employee due on check_day itself is compliant.
+
+Complexity summary (V = # groups, N = total # employees):
+    Time  : O(V + N) — visit every group once, every employee once.
+    Space : O(V) for the result dict + O(H) recursion depth
+            (H = tree height; H = V in the pathological linear-tree case).
 """
 
-from dataclasses import dataclass, field
+from __future__ import annotations
 
 
-@dataclass
 class Employee:
-    id: str
-    start_day: int
-    training_days_required: int
+    def __init__(self, name: str, start_day: int, training_days_required: int):
+        self.name = name
+        self.start_day = start_day
+        self.training_days_required = training_days_required
+
+    def overdue(self, check_day: int) -> int:
+        """Days overdue as of check_day, or 0 if compliant.
+
+        Time : O(1)
+        Space: O(1)
+        """
+        due_day = self.start_day + self.training_days_required
+        if check_day <= due_day:
+            return 0
+        return check_day - due_day
+
+    def is_compliant(self, check_day: int) -> bool:
+        return self.overdue(check_day) == 0
 
 
-# ---------- Q1: single-employee compliance ----------
-
-def overdue_days(emp: Employee, check_day: int) -> int:
-    """Return 0 if compliant, else positive number of days overdue."""
-    due_day = emp.start_day + emp.training_days_required
-    if check_day <= due_day:
-        return 0
-    return check_day - due_day
+class Group:
+    def __init__(self, g_id: str, sub_groups: list[Group], employees: list[Employee]):
+        self.g_id = g_id
+        self.sub_groups = sub_groups
+        self.employees = employees
 
 
-def is_compliant(emp: Employee, check_day: int) -> bool:
-    return overdue_days(emp, check_day) == 0
-
-
-# ---------- Q2: aggregate per group over a tree ----------
-
-@dataclass
 class GroupStats:
-    total_employees: int = 0
-    total_overdue_days: int = 0
+    def __init__(self, total_employees: int, total_overdue: int):
+        self.total_employees = total_employees
+        self.total_overdue = total_overdue
+
+    def __repr__(self) -> str:
+        return (
+            f"GroupStats(total_employees={self.total_employees}, "
+            f"total_overdue={self.total_overdue})"
+        )
 
 
-def aggregate_group_stats(
-    groups: dict[str, list[str]],          # parent_group_id -> list of child group ids
-    employees_by_group: dict[str, list[Employee]],  # group_id -> employees directly in it
-    check_day: int,
-) -> dict[str, GroupStats]:
-    """Return a dict mapping every group id to its aggregated stats over its subtree.
+def _dfs(curr: Group, check_day: int, out: dict[str, GroupStats]) -> GroupStats:
+    """Aggregate stats for `curr` and its subtree, writing every visited
+    group into `out`. Assumes a tree — each group visited exactly once.
 
-    Runs one DFS per connected component in the forest. Cost: O(V + E + N)
-    where N is total employees; each employee is visited once via its group.
+    Time : O(subtree_size_in_groups + subtree_employees)
+    Space: O(subtree_height) recursion
+    """
+    stats = GroupStats(0, 0)
+
+    for emp in curr.employees:
+        stats.total_employees += 1
+        stats.total_overdue += emp.overdue(check_day)
+
+    for child in curr.sub_groups:
+        child_stats = _dfs(child, check_day, out)
+        stats.total_employees += child_stats.total_employees
+        stats.total_overdue += child_stats.total_overdue
+
+    out[curr.g_id] = stats
+    return stats
+
+
+def compute_overdue(roots: list[Group], check_day: int) -> dict[str, GroupStats]:
+    """For each group in the forest rooted at `roots`, return its subtree stats.
+
+    Time : O(V + N)  — V groups, N employees, each visited once.
+    Space: O(V) result dict + O(H) recursion depth.
     """
     result: dict[str, GroupStats] = {}
-    # Discover every group id referenced (as parent, as child, or in employees_by_group)
-    all_group_ids: set[str] = set(groups.keys()) | set(employees_by_group.keys())
-    for children in groups.values():
-        all_group_ids.update(children)
-
-    # Find roots — groups that are not any other group's child.
-    child_of_someone: set[str] = {c for children in groups.values() for c in children}
-    roots = [g for g in all_group_ids if g not in child_of_someone]
-
-    def dfs(group_id: str) -> GroupStats:
-        # Employees directly in this group
-        stats = GroupStats()
-        for emp in employees_by_group.get(group_id, []):
-            stats.total_employees += 1
-            stats.total_overdue_days += overdue_days(emp, check_day)
-        # Recurse into subgroups
-        for child in groups.get(group_id, []):
-            child_stats = dfs(child)
-            stats.total_employees += child_stats.total_employees
-            stats.total_overdue_days += child_stats.total_overdue_days
-        result[group_id] = stats
-        return stats
-
     for root in roots:
-        dfs(root)
-
-    # Sanity: any group not visited (e.g., cycle in groups dict? shouldn't happen in a tree)
-    unvisited = all_group_ids - result.keys()
-    if unvisited:
-        # If input truly is a tree/forest this branch is unreachable. Raise so
-        # a bad input surfaces instead of silently returning partial data.
-        raise ValueError(f"unvisited groups (cycle or disconnected input?): {unvisited}")
-
+        _dfs(root, check_day, result)
     return result
 
 
@@ -105,35 +108,22 @@ def aggregate_group_stats(
 
 if __name__ == "__main__":
     # Q1 demo
-    alice = Employee("alice", start_day=10, training_days_required=30)
-    print("Q1  alice due day       :", alice.start_day + alice.training_days_required)  # 40
-    print("Q1  alice on day 35     :", overdue_days(alice, 35), "  compliant?", is_compliant(alice, 35))
-    print("Q1  alice on day 40     :", overdue_days(alice, 40), "  compliant?", is_compliant(alice, 40))
-    print("Q1  alice on day 50     :", overdue_days(alice, 50), "  compliant?", is_compliant(alice, 50))
+    alice = Employee("alice", start_day=10, training_days_required=30)  # due day 40
+    print("Q1  alice on day 35:", alice.overdue(35), "  compliant?", alice.is_compliant(35))
+    print("Q1  alice on day 40:", alice.overdue(40), "  compliant?", alice.is_compliant(40))
+    print("Q1  alice on day 50:", alice.overdue(50), "  compliant?", alice.is_compliant(50))
 
     # Q2 demo
-    #
-    # Group tree:
     #     eng
     #    /   \
     #  web  infra
     #        |
     #      db-oncall
-    #
-    groups = {
-        "eng": ["web", "infra"],
-        "infra": ["db-oncall"],
-        # web and db-oncall are leaves
-    }
-    employees_by_group = {
-        "web":       [Employee("bob",   start_day=0,  training_days_required=30)],
-        "infra":     [Employee("carol", start_day=5,  training_days_required=30)],
-        "db-oncall": [
-            Employee("dave", start_day=0,  training_days_required=30),
-            Employee("eve",  start_day=10, training_days_required=30),
-        ],
-    }
-    stats = aggregate_group_stats(groups, employees_by_group, check_day=60)
+    web = Group("web", [], [Employee("bob", 0, 30)])
+    db = Group("db-oncall", [], [Employee("dave", 0, 30), Employee("eve", 10, 30)])
+    infra = Group("infra", [db], [Employee("carol", 5, 30)])
+    eng = Group("eng", [web, infra], [])
+
+    stats = compute_overdue([eng], check_day=60)
     for gid in ["eng", "web", "infra", "db-oncall"]:
-        s = stats[gid]
-        print(f"Q2  {gid:12} employees={s.total_employees}  overdue_days={s.total_overdue_days}")
+        print(f"Q2  {gid:12} {stats[gid]}")

--- a/company-tags/vanta/employee_training.py
+++ b/company-tags/vanta/employee_training.py
@@ -1,0 +1,139 @@
+"""
+Vanta phone screen (backup problem): Employee Security Training & Group Aggregation.
+
+Q1: Given an Employee (start_day, training_days_required) and a check_day,
+    is the employee compliant? If not, how many days overdue?
+
+    An employee's training is due on day `start_day + training_days_required`.
+    Convention (CLARIFY with interviewer):
+      - If check_day <= start_day + training_days_required → compliant, overdue = 0.
+      - Else → overdue = check_day - (start_day + training_days_required).
+
+Q2: Employees live in a TREE of groups. For every group in the tree, compute:
+      - total_employees:   count of employees in this group's subtree
+      - total_overdue_days: sum of overdue days across all those employees
+                            (as of a given check_day)
+
+    Do it in one DFS — O(V + total_employees).
+
+Assumptions to CLARIFY:
+    - Is the group tree guaranteed connected / single root? (Handle forest below.)
+    - Are training-not-yet-started employees compliant? (Yes here.)
+    - Boundary: employee due on check_day itself — compliant? (Yes here.)
+"""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Employee:
+    id: str
+    start_day: int
+    training_days_required: int
+
+
+# ---------- Q1: single-employee compliance ----------
+
+def overdue_days(emp: Employee, check_day: int) -> int:
+    """Return 0 if compliant, else positive number of days overdue."""
+    due_day = emp.start_day + emp.training_days_required
+    if check_day <= due_day:
+        return 0
+    return check_day - due_day
+
+
+def is_compliant(emp: Employee, check_day: int) -> bool:
+    return overdue_days(emp, check_day) == 0
+
+
+# ---------- Q2: aggregate per group over a tree ----------
+
+@dataclass
+class GroupStats:
+    total_employees: int = 0
+    total_overdue_days: int = 0
+
+
+def aggregate_group_stats(
+    groups: dict[str, list[str]],          # parent_group_id -> list of child group ids
+    employees_by_group: dict[str, list[Employee]],  # group_id -> employees directly in it
+    check_day: int,
+) -> dict[str, GroupStats]:
+    """Return a dict mapping every group id to its aggregated stats over its subtree.
+
+    Runs one DFS per connected component in the forest. Cost: O(V + E + N)
+    where N is total employees; each employee is visited once via its group.
+    """
+    result: dict[str, GroupStats] = {}
+    # Discover every group id referenced (as parent, as child, or in employees_by_group)
+    all_group_ids: set[str] = set(groups.keys()) | set(employees_by_group.keys())
+    for children in groups.values():
+        all_group_ids.update(children)
+
+    # Find roots — groups that are not any other group's child.
+    child_of_someone: set[str] = {c for children in groups.values() for c in children}
+    roots = [g for g in all_group_ids if g not in child_of_someone]
+
+    def dfs(group_id: str) -> GroupStats:
+        # Employees directly in this group
+        stats = GroupStats()
+        for emp in employees_by_group.get(group_id, []):
+            stats.total_employees += 1
+            stats.total_overdue_days += overdue_days(emp, check_day)
+        # Recurse into subgroups
+        for child in groups.get(group_id, []):
+            child_stats = dfs(child)
+            stats.total_employees += child_stats.total_employees
+            stats.total_overdue_days += child_stats.total_overdue_days
+        result[group_id] = stats
+        return stats
+
+    for root in roots:
+        dfs(root)
+
+    # Sanity: any group not visited (e.g., cycle in groups dict? shouldn't happen in a tree)
+    unvisited = all_group_ids - result.keys()
+    if unvisited:
+        # If input truly is a tree/forest this branch is unreachable. Raise so
+        # a bad input surfaces instead of silently returning partial data.
+        raise ValueError(f"unvisited groups (cycle or disconnected input?): {unvisited}")
+
+    return result
+
+
+# ---------- demo ----------
+
+if __name__ == "__main__":
+    # Q1 demo
+    alice = Employee("alice", start_day=10, training_days_required=30)
+    print("Q1  alice due day       :", alice.start_day + alice.training_days_required)  # 40
+    print("Q1  alice on day 35     :", overdue_days(alice, 35), "  compliant?", is_compliant(alice, 35))
+    print("Q1  alice on day 40     :", overdue_days(alice, 40), "  compliant?", is_compliant(alice, 40))
+    print("Q1  alice on day 50     :", overdue_days(alice, 50), "  compliant?", is_compliant(alice, 50))
+
+    # Q2 demo
+    #
+    # Group tree:
+    #     eng
+    #    /   \
+    #  web  infra
+    #        |
+    #      db-oncall
+    #
+    groups = {
+        "eng": ["web", "infra"],
+        "infra": ["db-oncall"],
+        # web and db-oncall are leaves
+    }
+    employees_by_group = {
+        "web":       [Employee("bob",   start_day=0,  training_days_required=30)],
+        "infra":     [Employee("carol", start_day=5,  training_days_required=30)],
+        "db-oncall": [
+            Employee("dave", start_day=0,  training_days_required=30),
+            Employee("eve",  start_day=10, training_days_required=30),
+        ],
+    }
+    stats = aggregate_group_stats(groups, employees_by_group, check_day=60)
+    for gid in ["eng", "web", "infra", "db-oncall"]:
+        s = stats[gid]
+        print(f"Q2  {gid:12} employees={s.total_employees}  overdue_days={s.total_overdue_days}")

--- a/company-tags/vanta/employee_training_test.py
+++ b/company-tags/vanta/employee_training_test.py
@@ -1,0 +1,124 @@
+"""
+Tests for employee_training.py.
+
+Run: python employee_training_test.py
+"""
+
+import unittest
+
+from employee_training import (
+    Employee,
+    GroupStats,
+    aggregate_group_stats,
+    is_compliant,
+    overdue_days,
+)
+
+
+class TestQ1(unittest.TestCase):
+    def setUp(self):
+        self.emp = Employee("alice", start_day=10, training_days_required=30)  # due day 40
+
+    def test_before_due_day_compliant(self):
+        self.assertEqual(overdue_days(self.emp, 35), 0)
+        self.assertTrue(is_compliant(self.emp, 35))
+
+    def test_boundary_due_day_compliant(self):
+        # convention: employee due on day 40 is compliant on day 40
+        self.assertEqual(overdue_days(self.emp, 40), 0)
+        self.assertTrue(is_compliant(self.emp, 40))
+
+    def test_one_day_overdue(self):
+        self.assertEqual(overdue_days(self.emp, 41), 1)
+        self.assertFalse(is_compliant(self.emp, 41))
+
+    def test_many_days_overdue(self):
+        self.assertEqual(overdue_days(self.emp, 100), 60)
+
+    def test_check_day_before_start(self):
+        # Not yet started — compliant.
+        self.assertEqual(overdue_days(self.emp, 5), 0)
+        self.assertTrue(is_compliant(self.emp, 5))
+
+
+class TestQ2(unittest.TestCase):
+    def small_tree(self):
+        # eng
+        # ├── web         [bob due=30]
+        # └── infra       [carol due=35]
+        #     └── db-oncall  [dave due=30, eve due=40]
+        groups = {
+            "eng": ["web", "infra"],
+            "infra": ["db-oncall"],
+        }
+        employees_by_group = {
+            "web":       [Employee("bob",   0,  30)],
+            "infra":     [Employee("carol", 5,  30)],
+            "db-oncall": [
+                Employee("dave", 0,  30),
+                Employee("eve",  10, 30),
+            ],
+        }
+        return groups, employees_by_group
+
+    def test_leaf_group(self):
+        groups, empg = self.small_tree()
+        stats = aggregate_group_stats(groups, empg, check_day=60)
+        # web has just bob (due=30, check=60 → 30 overdue)
+        self.assertEqual(stats["web"].total_employees, 1)
+        self.assertEqual(stats["web"].total_overdue_days, 30)
+
+    def test_intermediate_group(self):
+        groups, empg = self.small_tree()
+        stats = aggregate_group_stats(groups, empg, check_day=60)
+        # infra = carol (25 overdue: due=35) + db-oncall subtree (dave=30, eve=20)
+        # total employees = 3 (carol, dave, eve)
+        # total overdue = 25 + 30 + 20 = 75
+        self.assertEqual(stats["infra"].total_employees, 3)
+        self.assertEqual(stats["infra"].total_overdue_days, 75)
+
+    def test_root_group_aggregates_everyone(self):
+        groups, empg = self.small_tree()
+        stats = aggregate_group_stats(groups, empg, check_day=60)
+        # eng = bob + carol + dave + eve
+        # total overdue = 30 (bob) + 25 (carol) + 30 (dave) + 20 (eve) = 105
+        self.assertEqual(stats["eng"].total_employees, 4)
+        self.assertEqual(stats["eng"].total_overdue_days, 105)
+
+    def test_all_compliant_check_day(self):
+        groups, empg = self.small_tree()
+        # check_day = 30: bob due=30 compliant, carol due=35 compliant, dave due=30 compliant, eve due=40 compliant
+        stats = aggregate_group_stats(groups, empg, check_day=30)
+        self.assertEqual(stats["eng"].total_overdue_days, 0)
+        # employee count unaffected by compliance
+        self.assertEqual(stats["eng"].total_employees, 4)
+
+    def test_empty_group_with_no_subgroups(self):
+        # A group with no employees and no subgroups should still appear with zeros.
+        groups = {"eng": ["empty"]}
+        empg = {"eng": [Employee("bob", 0, 30)]}
+        stats = aggregate_group_stats(groups, empg, check_day=50)
+        self.assertEqual(stats["empty"].total_employees, 0)
+        self.assertEqual(stats["empty"].total_overdue_days, 0)
+        self.assertEqual(stats["eng"].total_employees, 1)
+        self.assertEqual(stats["eng"].total_overdue_days, 20)
+
+    def test_forest_multiple_roots(self):
+        # Two disjoint trees
+        groups = {
+            "eng": ["web"],
+            "sales": ["ae"],
+        }
+        empg = {
+            "web": [Employee("bob", 0, 30)],
+            "ae":  [Employee("carol", 0, 30)],
+        }
+        stats = aggregate_group_stats(groups, empg, check_day=60)
+        self.assertEqual(stats["eng"].total_employees, 1)
+        self.assertEqual(stats["sales"].total_employees, 1)
+        self.assertEqual(stats["eng"].total_overdue_days, 30)
+        self.assertEqual(stats["sales"].total_overdue_days, 30)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/company-tags/vanta/employee_training_test.py
+++ b/company-tags/vanta/employee_training_test.py
@@ -8,116 +8,115 @@ import unittest
 
 from employee_training import (
     Employee,
+    Group,
     GroupStats,
-    aggregate_group_stats,
-    is_compliant,
-    overdue_days,
+    compute_overdue,
 )
 
 
-class TestQ1(unittest.TestCase):
+class TestEmployeeOverdue(unittest.TestCase):
     def setUp(self):
-        self.emp = Employee("alice", start_day=10, training_days_required=30)  # due day 40
+        # due day = 10 + 30 = 40
+        self.emp = Employee("alice", start_day=10, training_days_required=30)
 
     def test_before_due_day_compliant(self):
-        self.assertEqual(overdue_days(self.emp, 35), 0)
-        self.assertTrue(is_compliant(self.emp, 35))
+        self.assertEqual(self.emp.overdue(35), 0)
+        self.assertTrue(self.emp.is_compliant(35))
 
     def test_boundary_due_day_compliant(self):
         # convention: employee due on day 40 is compliant on day 40
-        self.assertEqual(overdue_days(self.emp, 40), 0)
-        self.assertTrue(is_compliant(self.emp, 40))
+        self.assertEqual(self.emp.overdue(40), 0)
+        self.assertTrue(self.emp.is_compliant(40))
 
     def test_one_day_overdue(self):
-        self.assertEqual(overdue_days(self.emp, 41), 1)
-        self.assertFalse(is_compliant(self.emp, 41))
+        self.assertEqual(self.emp.overdue(41), 1)
+        self.assertFalse(self.emp.is_compliant(41))
 
     def test_many_days_overdue(self):
-        self.assertEqual(overdue_days(self.emp, 100), 60)
+        self.assertEqual(self.emp.overdue(100), 60)
 
     def test_check_day_before_start(self):
         # Not yet started — compliant.
-        self.assertEqual(overdue_days(self.emp, 5), 0)
-        self.assertTrue(is_compliant(self.emp, 5))
+        self.assertEqual(self.emp.overdue(5), 0)
+        self.assertTrue(self.emp.is_compliant(5))
 
 
-class TestQ2(unittest.TestCase):
+class TestComputeOverdue(unittest.TestCase):
     def small_tree(self):
         # eng
         # ├── web         [bob due=30]
         # └── infra       [carol due=35]
         #     └── db-oncall  [dave due=30, eve due=40]
-        groups = {
-            "eng": ["web", "infra"],
-            "infra": ["db-oncall"],
-        }
-        employees_by_group = {
-            "web":       [Employee("bob",   0,  30)],
-            "infra":     [Employee("carol", 5,  30)],
-            "db-oncall": [
-                Employee("dave", 0,  30),
-                Employee("eve",  10, 30),
-            ],
-        }
-        return groups, employees_by_group
+        web = Group("web", [], [Employee("bob", 0, 30)])
+        db = Group("db-oncall", [], [Employee("dave", 0, 30), Employee("eve", 10, 30)])
+        infra = Group("infra", [db], [Employee("carol", 5, 30)])
+        eng = Group("eng", [web, infra], [])
+        return eng
 
     def test_leaf_group(self):
-        groups, empg = self.small_tree()
-        stats = aggregate_group_stats(groups, empg, check_day=60)
+        eng = self.small_tree()
+        stats = compute_overdue([eng], check_day=60)
         # web has just bob (due=30, check=60 → 30 overdue)
         self.assertEqual(stats["web"].total_employees, 1)
-        self.assertEqual(stats["web"].total_overdue_days, 30)
+        self.assertEqual(stats["web"].total_overdue, 30)
 
     def test_intermediate_group(self):
-        groups, empg = self.small_tree()
-        stats = aggregate_group_stats(groups, empg, check_day=60)
-        # infra = carol (25 overdue: due=35) + db-oncall subtree (dave=30, eve=20)
-        # total employees = 3 (carol, dave, eve)
-        # total overdue = 25 + 30 + 20 = 75
+        eng = self.small_tree()
+        stats = compute_overdue([eng], check_day=60)
+        # infra = carol (25) + db-oncall subtree (dave=30, eve=20) = 75, 3 emps
         self.assertEqual(stats["infra"].total_employees, 3)
-        self.assertEqual(stats["infra"].total_overdue_days, 75)
+        self.assertEqual(stats["infra"].total_overdue, 75)
 
     def test_root_group_aggregates_everyone(self):
-        groups, empg = self.small_tree()
-        stats = aggregate_group_stats(groups, empg, check_day=60)
-        # eng = bob + carol + dave + eve
-        # total overdue = 30 (bob) + 25 (carol) + 30 (dave) + 20 (eve) = 105
+        eng = self.small_tree()
+        stats = compute_overdue([eng], check_day=60)
+        # eng = bob(30) + carol(25) + dave(30) + eve(20) = 105
         self.assertEqual(stats["eng"].total_employees, 4)
-        self.assertEqual(stats["eng"].total_overdue_days, 105)
+        self.assertEqual(stats["eng"].total_overdue, 105)
 
     def test_all_compliant_check_day(self):
-        groups, empg = self.small_tree()
-        # check_day = 30: bob due=30 compliant, carol due=35 compliant, dave due=30 compliant, eve due=40 compliant
-        stats = aggregate_group_stats(groups, empg, check_day=30)
-        self.assertEqual(stats["eng"].total_overdue_days, 0)
-        # employee count unaffected by compliance
+        eng = self.small_tree()
+        stats = compute_overdue([eng], check_day=30)
+        self.assertEqual(stats["eng"].total_overdue, 0)
         self.assertEqual(stats["eng"].total_employees, 4)
 
     def test_empty_group_with_no_subgroups(self):
-        # A group with no employees and no subgroups should still appear with zeros.
-        groups = {"eng": ["empty"]}
-        empg = {"eng": [Employee("bob", 0, 30)]}
-        stats = aggregate_group_stats(groups, empg, check_day=50)
+        empty = Group("empty", [], [])
+        eng = Group("eng", [empty], [Employee("bob", 0, 30)])
+        stats = compute_overdue([eng], check_day=50)
         self.assertEqual(stats["empty"].total_employees, 0)
-        self.assertEqual(stats["empty"].total_overdue_days, 0)
+        self.assertEqual(stats["empty"].total_overdue, 0)
         self.assertEqual(stats["eng"].total_employees, 1)
-        self.assertEqual(stats["eng"].total_overdue_days, 20)
+        self.assertEqual(stats["eng"].total_overdue, 20)
 
     def test_forest_multiple_roots(self):
-        # Two disjoint trees
-        groups = {
-            "eng": ["web"],
-            "sales": ["ae"],
-        }
-        empg = {
-            "web": [Employee("bob", 0, 30)],
-            "ae":  [Employee("carol", 0, 30)],
-        }
-        stats = aggregate_group_stats(groups, empg, check_day=60)
+        eng = Group("eng", [], [Employee("bob", 0, 30)])
+        sales = Group("sales", [], [Employee("carol", 0, 30)])
+        stats = compute_overdue([eng, sales], check_day=60)
         self.assertEqual(stats["eng"].total_employees, 1)
         self.assertEqual(stats["sales"].total_employees, 1)
-        self.assertEqual(stats["eng"].total_overdue_days, 30)
-        self.assertEqual(stats["sales"].total_overdue_days, 30)
+        self.assertEqual(stats["eng"].total_overdue, 30)
+        self.assertEqual(stats["sales"].total_overdue, 30)
+
+    def test_wide_tree_mixed_overdue(self):
+        # A ── B [e3=3, e4=1]
+        #   ── C [e5=1, e6=0, e7=4]
+        #   ── D [e8=7, e9=1]
+        # e1=2, e2=0 direct on A
+        check_day = 100
+        def emp(name, ov):
+            return Employee(name, 70 - ov, 30)
+
+        B = Group("B", [], [emp("e3", 3), emp("e4", 1)])
+        C = Group("C", [], [emp("e5", 1), emp("e6", 0), emp("e7", 4)])
+        D = Group("D", [], [emp("e8", 7), emp("e9", 1)])
+        A = Group("A", [B, C, D], [emp("e1", 2), emp("e2", 0)])
+
+        stats = compute_overdue([A], check_day=check_day)
+        self.assertEqual(stats["B"].total_employees, 2); self.assertEqual(stats["B"].total_overdue, 4)
+        self.assertEqual(stats["C"].total_employees, 3); self.assertEqual(stats["C"].total_overdue, 5)
+        self.assertEqual(stats["D"].total_employees, 2); self.assertEqual(stats["D"].total_overdue, 8)
+        self.assertEqual(stats["A"].total_employees, 9); self.assertEqual(stats["A"].total_overdue, 19)
 
 
 if __name__ == "__main__":

--- a/company-tags/vanta/onsite/README.md
+++ b/company-tags/vanta/onsite/README.md
@@ -1,0 +1,13 @@
+# Vanta Onsite — Reference
+
+Not primary focus yet (phone screen first), but here for reference so you don't context-switch cold if you advance.
+
+- [`round1-coding.md`](./round1-coding.md) — practical coding (same family as phone screen, may involve file I/O)
+- [`round2-system-design.md`](./round2-system-design.md) — DAU/MAU tracking system
+- [`round3-principle.md`](./round3-principle.md) — scenario behavioral
+- [`round4-project.md`](./round4-project.md) — project deep-dive
+- [`round5-rag-pipeline.md`](./round5-rag-pipeline.md) — RAG for compliance docs
+
+Cross-links:
+- The RAG round shares content with [`../../../tracks/genai-mle/ml-sys-design.md`](../../../tracks/genai-mle/ml-sys-design.md).
+- The DAU/MAU round shares content with `../../../system-design/mocks/`.

--- a/company-tags/vanta/onsite/round1-coding.md
+++ b/company-tags/vanta/onsite/round1-coding.md
@@ -1,0 +1,44 @@
+# Round 1 — Practical Coding
+
+Same "uniq" family as the phone screen. Reports suggest the followup may include reading from a file rather than a fixed literal in the source. Have your local Python dev loop rehearsed so you can pipe input in:
+
+```bash
+cat input.txt | python solution.py
+# or
+python solution.py < input.txt
+# or
+python solution.py input.txt   # if the interviewer wants argv
+```
+
+## What to warm up
+
+- `sys.stdin.read()` / `sys.stdin.readlines()` / iterating `sys.stdin` line by line.
+- `json.load(sys.stdin)` if the input is JSON.
+- `csv.reader` if tabular.
+- `argparse` — but for a 25-min problem, `sys.argv[1]` is fine.
+
+## Likely follow-ups on top of the phone screen problems
+
+- **Task Dependency variant:** input is a JSON blob `[{id, dependencies}]`. Parse, then run Q1/Q2.
+- **Employee Training variant:** input is a CSV of `employee_id,group_id,start_day,training_days_required`. Parse, build the group tree, run aggregation.
+
+## Practice loop
+
+Take your phone-screen solutions and wrap them with:
+
+```python
+import json, sys
+if __name__ == "__main__":
+    data = json.load(sys.stdin)
+    tasks = [Task(**t) for t in data["tasks"]]
+    targets = data["targets"]
+    print(dependencies_of_targets(tasks, targets))
+```
+
+Then feed them a JSON file and confirm output. That's the muscle memory you need.
+
+## Common failure modes
+
+- Reaching for `pandas` for a 20-line CSV. Overkill; `csv.reader` is enough.
+- Not handling trailing newlines / BOM in the input.
+- Forgetting that `input()` returns `str`, not `int`. `int(input())` when needed.

--- a/company-tags/vanta/onsite/round2-system-design.md
+++ b/company-tags/vanta/onsite/round2-system-design.md
@@ -1,0 +1,104 @@
+# Round 2 — System Design: DAU / MAU Tracking
+
+Reported multiple times as the specific prompt: **Design a system to track Daily Active Users (DAU) and Monthly Active Users (MAU).** Vanta's product is compliance-facing so the "user" is a customer employee touching the platform; scale is modest by consumer-app standards (~millions of end-users across their customer base, not billions).
+
+Use Alireza's/ByteByteGo-style scaffold — the interviewer wants to see structure, not cleverness.
+
+## 1. Clarifying questions (spend 5 min here)
+
+- **Definition of "active":** any HTTP request? A meaningful action (login, doc upload, evidence review)? Ask.
+- **Scale:** how many customers × employees each × avg actions/day? Rough order: 10K customers × 100 users × 20 actions/day ≈ 20M events/day.
+- **Latency requirements:** query freshness — real-time (last-minute) or 15-min-lagging is OK?
+- **Precision:** must DAU/MAU be exact, or is an HLL-based approximate count acceptable? (Approximate is usually fine.)
+- **Retention:** how long do we keep event-level data vs aggregates?
+- **Tenancy:** DAU/MAU per-customer (tenant), or global? (Almost certainly per-tenant for a B2B compliance product.)
+- **Auditability:** since this is compliance, do we need immutable event logs?
+
+## 2. Functional requirements
+
+- Ingest user activity events at high write throughput.
+- Compute DAU (unique users in the last calendar day) and MAU (unique users in the last 30 days).
+- Query: per tenant, per date range, current running total.
+- Historical time-series: show DAU over the last N days.
+
+## 3. Non-functional
+
+- Availability: 99.9%.
+- Freshness: <5 min for the current day's counter.
+- Cost: linear in events, ideally sub-linear in queries.
+- Correctness under retries: idempotent event ingestion (dedup on client-side event id).
+
+## 4. Estimate
+
+- 20M events/day = 230 events/sec average, ~1K peak.
+- Event payload: 200 bytes → 4 GB/day raw. 1.5 TB/year retained.
+
+## 5. High-level architecture
+
+```
+Clients ─→ API Gateway ─→ Kafka (activity_events topic)
+                                │
+              ┌─────────────────┼─────────────────┐
+              ▼                 ▼                 ▼
+       Real-time counter   Batch aggregator   Raw log sink
+       (Redis + HLL)       (Spark / dbt      (S3 / data lake)
+                            per-day rollup)
+                                │
+                                ▼
+                        Time-series store
+                        (Postgres w/ TimescaleDB,
+                         or ClickHouse)
+                                │
+                                ▼
+                        Query API + dashboard
+```
+
+## 6. Design decisions to defend
+
+### HyperLogLog (HLL) for the hot path
+
+- DAU/MAU are cardinality queries. Exact set counting scales as O(n) memory per (day, tenant) — 100K employees × 10K tenants × 30 days quickly blows up.
+- HLL gives you a **fixed-size sketch (~1.5 KB per bucket) with ~2% relative error**. Redis has native `PFADD` / `PFCOUNT` / `PFMERGE`.
+- MAU can be computed by merging 30 daily HLL sketches → single-pass, ~50KB.
+
+Trade-off: HLL is approximate. If the interviewer asks for exact counts, discuss bitmap-per-user-per-day (`Roaring bitmaps`) as an alternative — exact but heavier.
+
+### Deduplication
+
+- Client sends `event_id` (UUID). Ingestion side stores recent event ids in a bloom filter (or Redis SET with TTL) to drop duplicates before they hit the counter.
+
+### Tenant isolation
+
+- Keys are namespaced: `dau:{tenant_id}:{date}` and `mau:{tenant_id}:{date_prefix}`.
+- Query API enforces tenant ID from the auth context; never trust the URL.
+
+### Time-series storage
+
+- Rollups written daily to Postgres/Timescale hypertable OR ClickHouse. One row per (tenant, date, dau, mau).
+- Retention: raw events S3 for N years (compliance), sketches Redis for 32 days, rolled-up counts forever.
+
+## 7. Deep dives the interviewer might drill
+
+- **Late-arriving events.** An event with `timestamp = yesterday` shows up today. Options: window-of-tolerance, replay job, or "at write time we bucket by event.timestamp not receive_time".
+- **HLL bias correction.** For small cardinalities HLL over-estimates. Redis's implementation uses HLL++ which handles this. Say so.
+- **Scaling ingestion.** Kafka partitions by tenant_id → per-tenant ordering, hot tenants get more partitions.
+- **Timezone.** DAU "day" — UTC or tenant's local timezone? Cheap gotcha; ask upfront.
+- **Multi-region.** If tenants span regions, do we keep tenants on the region where they were provisioned, or replicate?
+- **Backfill.** Someone asks for DAU/MAU for a period before the system existed. Show: replay raw events from S3 → regenerate sketches.
+
+## 8. Considerations
+
+- **Compliance-flavored twist:** since Vanta sells SOC 2, they DO care about immutability of audit logs. The raw event sink to S3 with object lock is not just for "cost", it's a compliance artifact.
+- **Cost:** ~20M events/day at Kafka cost is trivial; the HLL memory is trivial; the biggest cost is retention of raw logs.
+- **Privacy:** GDPR right-to-delete. HLL sketches can't be selectively edited — plan for periodic recomputation from raw logs after deletions.
+
+## 9. Iteration / follow-ups
+
+- V2: cohort retention (DAU by signup cohort).
+- V3: feature-level DAU (which product surface is being used).
+- V4: anomaly detection on DAU curves.
+
+## Related material in this repo
+
+- `system-design/mocks/` — general system design mock catalog
+- [`tracks/genai-mle/ml-sys-design.md`](../../../tracks/genai-mle/ml-sys-design.md) — Alireza's 9-step scaffold (though this one is a classic sys design, not ML sys design)

--- a/company-tags/vanta/onsite/round3-principle.md
+++ b/company-tags/vanta/onsite/round3-principle.md
@@ -1,0 +1,60 @@
+# Round 3 — "Principle" (Scenario Behavioral)
+
+Vanta's behavioral round is **not** standard STAR ("tell me about a time when..."). Interviewers present a hypothetical scenario and ask how you'd handle it. It tests judgment, decision-making, and how you weigh tradeoffs.
+
+**Critical warning from a candidate report:** even though HR framed it as scenario-only, the interviewer dinged them for not grounding answers in concrete examples. **Bring your stories anyway** — use them as evidence when the scenario answer needs backing.
+
+## Format
+
+- Interviewer describes a situation (e.g., "You're a tech lead. Half your team wants to migrate to Rust; the other half wants to stay on Python. How do you handle it?").
+- You reason out loud about the scenario.
+- Follow-ups probe your reasoning.
+- Interviewer may ask "have you actually done something like this?" — that's when you drop a real story.
+
+## Framework for answering scenarios
+
+Use this shape unconsciously; don't announce it:
+
+1. **Clarify.** Ask 1–2 questions to pin down constraints ("What's the timeline? What's the team size? Is there a business pressure driving one option?").
+2. **Frame the tradeoff.** State what's actually being decided ("This is really a question about migration risk vs long-term velocity, not about the languages themselves.").
+3. **Propose.** Give a concrete plan or decision. Prefer options that reduce risk (small pilot, reversible move, data before decision).
+4. **Own the downside.** Say what could go wrong with your choice.
+5. **Ground.** Attach one 2-sentence story where you handled something similar.
+
+## Anticipated scenarios (drill these)
+
+Vanta hires for a compliance/security product. Their behavioral scenarios often center on:
+
+- **Security incident.** "A customer reports their SOC 2 evidence is showing up in another customer's dashboard. It's Friday at 5pm. Walk me through the first hour." → Blast-radius mindset, incident commander, communication cadence.
+- **Ambiguous priority.** "Product wants a feature by Q4; security wants a hardening sprint; your PM has moved on. What do you do?" → Frame as "who's the customer of each work item, what's the cost of delay for each".
+- **Underperforming teammate.** "Someone on your team is missing deadlines and morale is dropping. What do you do?" → Empathy + specificity + escalation path.
+- **Disagreement with a leader.** "Your VP is pushing a decision you think is technically wrong. How?" → Disagree-and-commit, but establish the disagreement in writing first.
+- **Post-mortem culture.** "Your team just shipped a bug that took down a customer's audit. Blame vs learn?" → Blameless post-mortem, but with an owner for follow-ups.
+- **Cross-team dependency slipping.** "Your feature depends on Platform, and they're a month late. What do you do?" → Options: unblock yourself, negotiate scope, escalate. Show all three, pick one.
+
+## Stories you should have ready (from your Amazon LP prep doc)
+
+Repurpose 4–6 hero stories, filtered for Vanta-flavored themes:
+
+1. **Ownership over ambiguous scope** — you saw something broken outside your remit and fixed it.
+2. **Disagree-and-commit** — you pushed back on a decision, made your case in writing, then executed the leader's decision fully.
+3. **Post-mortem you led** — walk through incident, comms, follow-ups.
+4. **Cross-functional impact** — you influenced a decision outside your team without authority.
+5. **Mentorship / growing someone** — the specific person, the specific delta.
+6. **Failed project + what you learned** — Vanta will ask this in some form.
+
+## Things NOT to do
+
+- Answer in pure abstraction ("well, you'd have to weigh the pros and cons..."). Interviewer wants a decision.
+- Skip clarifying questions and jump to a plan. Reports say the interviewer values the pause to think.
+- Recite a rehearsed STAR story that doesn't match the scenario. If it doesn't fit, don't force it.
+- Bring up Vanta's competitors negatively. Small industry.
+
+## Preparation drill
+
+For each anticipated scenario above:
+- Write out your framing + decision in <200 words.
+- Attach one real story from your prep doc.
+- Time-box each answer to 4 minutes when practicing aloud.
+
+**Total prep:** ~2 hours to write all six + drill.

--- a/company-tags/vanta/onsite/round4-project.md
+++ b/company-tags/vanta/onsite/round4-project.md
@@ -1,0 +1,78 @@
+# Round 4 — HM / Project Deep-Dive
+
+Standard hiring-manager round: walk through a project you've owned. Vanta's HMs care about:
+
+- **Scope you actually owned** — not just contributed to, but drove.
+- **Cross-functional impact** — did design/product/security/legal show up? How did you manage them?
+- **Ownership** — what did you do when things went sideways? Did you signal early, drive to resolution, own the follow-up?
+- **Business or customer outcome** — what actually changed for the customer, not just what you shipped.
+
+## Choosing the project
+
+Pick ONE project as your primary and have ONE backup. The primary should:
+
+- Be recent (last 18 months) so you remember details.
+- Have real scope (multiple engineers, multiple weeks, not a bug fix).
+- Have measurable outcome (X% latency reduction, $Y saved, N customers unblocked).
+- Have friction you can talk about (rewrite decisions, deadline slips, cross-team pushback).
+
+Bad choice: a project where your role was ambiguous, or where you can't quantify impact.
+
+## Storyboard (memorize this arc)
+
+1. **Context** (1 min) — What was the state of the world before this project? What problem existed?
+2. **Why me** (30 sec) — Why did the org pick you / how did you end up owning it?
+3. **What I did** (3 min) — The 3–5 major decisions and their rationale. NOT a chronological narrative — organized by decision.
+4. **What went wrong** (2 min) — At least one honest hiccup. What surprised you, how you responded.
+5. **Impact** (1 min) — Numbers. Customer testimonials. What the org can now do that it couldn't before.
+6. **What I'd do differently** (1 min) — Show you learned. Not a false-humility answer.
+
+## Prompts the HM will drill on
+
+- "Why did you choose X over Y?"
+- "What was the biggest trade-off?"
+- "Who disagreed with you and how did you handle it?"
+- "What did you delegate vs do yourself?"
+- "How did you measure success?"
+- "What would you do differently?"
+- "Who did you influence outside your team?"
+- "How did leadership stay aligned with you during the project?"
+
+## Anti-patterns
+
+- **Team-we-we-we.** Interviewer wants your specific contribution. "We built X" → "I owned the design; here's the doc I wrote; here's the decision I made against Y approach."
+- **Only success narrative.** No honest reflection = looks polished but shallow. Bring one real hiccup.
+- **Getting into implementation weeds too early.** Start at the "why" and "what changed", then dive into HOW only when they ask.
+- **Not knowing the numbers.** If you can't state the impact quantitatively, pick a different project.
+
+## Prep drill
+
+Write a 1-page project summary in this shape:
+
+```
+Project: [name, ~10 words]
+Timeline: [start – end]
+Team: [size, my role]
+Problem:
+Approach:
+Key decisions (3–5):
+Hiccup / recovery:
+Impact:
+Would do differently:
+Owned:  [3 bullets — what specifically I drove]
+```
+
+Rehearse the 5-minute version aloud, then the 15-minute deep-dive version.
+
+## Vanta-flavored angles
+
+If your project touches any of these, lean into them:
+
+- Security posture / compliance ("we needed to ship this without breaking SOC 2 requirements")
+- Trust and safety
+- B2B integrations / SSO / SCIM
+- Multi-tenant infrastructure
+- Audit trails and immutable logs
+- Data privacy / GDPR / SOC 2 type controls
+
+If your project doesn't touch these, don't fake it — pick strengths (scale, velocity, mentorship, cross-team) and lean into those instead.

--- a/company-tags/vanta/onsite/round5-rag-pipeline.md
+++ b/company-tags/vanta/onsite/round5-rag-pipeline.md
@@ -1,0 +1,149 @@
+# Round 5 — AI Technical Deep-Dive: RAG for Compliance Docs
+
+Newer onsite round. Reported prompt: **Design an AI/RAG pipeline related to Vanta's GRC product.**
+
+## Context
+
+Vanta automates compliance (SOC 2, ISO 27001, HIPAA, GDPR, PCI, etc.). Their AI-facing product surface:
+- Ingest customer's internal docs (security policies, employee handbooks, vendor agreements, cloud config exports).
+- Analyze them for compliance gaps against a target framework.
+- Suggest remediation, generate evidence for auditors, answer compliance-vocabulary questions.
+
+**They do NOT expect you to know GRC.** They expect you to know RAG architecture cold, and to reason about the compliance domain from first principles when they steer the discussion.
+
+## Skeleton (reuse Alireza's 9-step + RAG specifics)
+
+Cross-reference: [`../../../tracks/genai-mle/ml-sys-design.md`](../../../tracks/genai-mle/ml-sys-design.md).
+
+### 1. Problem statement
+
+- Customer uploads a corpus of internal docs.
+- System answers questions grounded in those docs OR flags compliance gaps against a framework (e.g., "does this cover access review?").
+- Bar: answers must cite sources (compliance is untrustworthy without citations); model must NOT hallucinate control coverage.
+
+### 2. Data
+
+- **Inputs:** PDFs, DOCX, HTML pages exported from Confluence/Notion/Google Docs, CSV of asset inventories, JSON from cloud audit exports (AWS Config, GCP Cloud Asset Inventory).
+- **Framework knowledge:** SOC 2 Trust Services Criteria, ISO 27001 Annex A, etc. — a curated corpus Vanta maintains internally.
+- **Labels for evals:** hand-curated question/answer pairs from Vanta's own SMEs.
+
+### 3. Model / architecture
+
+```
+┌────────────┐   ┌───────────┐   ┌──────────────┐   ┌────────────────┐
+│  Ingestion │──▶│ Chunker   │──▶│ Embedder     │──▶│ Vector store   │
+│  (PDF/HTML │   │           │   │ (bge, e5,    │   │ (pgvector /    │
+│  parsers)  │   │           │   │  OpenAI text │   │  Weaviate /    │
+└────────────┘   └───────────┘   │  -embed-3)   │   │  Pinecone)     │
+                                 └──────────────┘   └────────────────┘
+                                                             │
+                                                             ▼
+┌────────────┐   ┌──────────────┐   ┌─────────────┐   ┌────────────┐
+│ User query │──▶│ Query reform │──▶│ Retriever   │──▶│ Reranker   │
+│            │   │ (LLM-based,  │   │ (hybrid:    │   │ (cross-    │
+│            │   │  optional)   │   │  BM25 +     │   │  encoder)  │
+└────────────┘   └──────────────┘   │  vector)    │   └────────────┘
+                                    └─────────────┘         │
+                                                            ▼
+                                          ┌───────────────────────────┐
+                                          │  LLM (Claude / GPT-4-turbo)│
+                                          │  + system prompt          │
+                                          │  + retrieved chunks       │
+                                          │  + citation guardrail     │
+                                          └───────────────────────────┘
+                                                            │
+                                                            ▼
+                                          ┌────────────────────────────┐
+                                          │  Post-processor: citations,│
+                                          │  fact-check pass,          │
+                                          │  no-answer fallback        │
+                                          └────────────────────────────┘
+```
+
+### Chunking strategy (they WILL ask)
+
+- Naive fixed-size (500 tokens) chunking loses structure. Compliance docs have headings, tables, control IDs — chunking should respect them.
+- Recommended: hierarchical chunking + parent-doc retrieval. Small chunks for retrieval, larger parent context in the LLM prompt.
+- Table extraction: PDFs of policies often have tables (control matrices). Use a layout-aware parser (Unstructured.io, Azure Doc Intelligence, LlamaParse).
+
+### Retrieval
+
+- **Hybrid** (BM25 + dense embeddings) beats dense-only for compliance because control names / IDs are keyword-heavy.
+- Metadata filters — every chunk tagged with `doc_id`, `section`, `framework`, `control_id`, `last_updated`. Filter before ANN search.
+- Reranking: cross-encoder on top-50 → top-10.
+
+### Generation
+
+- Model choice: Claude 3.5 Sonnet or GPT-4-turbo for reasoning; smaller models for orchestration.
+- System prompt enforces: "Cite source doc + section number for every claim. If the corpus doesn't cover the question, say 'This is not addressed in your uploaded policies.'"
+- Constrained output for gap analysis: force JSON with `{control_id, is_covered, evidence: [chunk_ids], remediation}`.
+
+### 4. Evaluation (spend real time here)
+
+Compliance context makes evals load-bearing:
+
+- **Retrieval quality:** hit rate @ K, MRR against a golden set.
+- **Faithfulness (RAGAS):** does the answer only use information in retrieved chunks?
+- **Groundedness:** every claim has a citation.
+- **Answer relevance:** does the answer address the question?
+- **Coverage:** for gap analysis, precision/recall vs SME-labeled gaps.
+- **Hallucination detection:** LLM-as-judge on a held-out set with disclaimers.
+- **Regression suite:** every model change → run 200-example golden set, block ship on regression.
+
+### 5. Serving
+
+- API: streaming responses for the chat UI, non-streaming for the analysis job.
+- Async gap-analysis job: batch all controls, run in parallel, return report.
+- Caching: query-level (Redis, 24h TTL), embedding-level (persistent — embeddings are expensive).
+- Rate limiting per customer.
+
+### 6. Monitoring & feedback
+
+- Log every query + retrieved chunks + answer + citations.
+- User feedback: 👍/👎, "the answer was wrong because..." (freeform).
+- Drift detection: shift in retrieval distributions after new doc upload.
+- Cost per query, tail latency (p95, p99).
+
+### 7. Iteration
+
+- V1: single-framework (SOC 2 only), off-the-shelf embedder, GPT-4-turbo.
+- V2: multi-framework, hybrid retrieval, custom reranker.
+- V3: agentic flow — LLM decides when to search vs when to answer, when to escalate to a human.
+- V4: fine-tuned embedding on compliance corpus for domain shift.
+
+### 8. Considerations
+
+- **Data isolation.** Every customer's data must stay in their tenant. Vector index is per-tenant; multi-tenant embedding models are OK as long as inference doesn't leak.
+- **Privacy.** Customer data cannot be used to train foundation models. If using OpenAI/Anthropic APIs, use zero-retention endpoints and get contractual guarantees.
+- **PII detection.** Compliance docs may contain PII (employee names in a policy). Redact before indexing or before sending to a third-party API.
+- **Audit trail.** Every LLM interaction is logged (compliance meta-story). What did we retrieve? What did we generate? Immutable audit log.
+- **Human-in-the-loop.** For high-stakes claims (SOC 2 control coverage), gate on human approval before customer-visible.
+
+### 9. Deep dives the interviewer WILL steer to
+
+- **Hallucination mitigation.** Answer:
+  - Constrain output format (structured JSON, "no answer" is a valid response).
+  - Post-hoc verifier LLM checks answer-vs-chunks consistency.
+  - LLM-as-judge on a held-out set as a regression gate.
+- **Doc changes / re-indexing.** Customer updates their access policy. What do you do?
+  - Incremental re-index on `last_updated` changes.
+  - Version chunks; keep old + new so audit history is preserved.
+- **Multi-doc reasoning.** "Are our access reviews compliant?" spans employee handbook + IAM audit log + AWS Config export. Needs multi-hop retrieval OR an agent.
+- **Cold start.** New customer with zero docs. What does the product show them?
+  - Framework-default recommendations, ask for specific doc uploads.
+- **Cost.** Embed once (cheap-ish), rerank per query (moderate), LLM generate per query (expensive). Cost model:
+  - Ingest: 100 docs × 500 chunks × $0.0001 = $5/customer one-time.
+  - Query: $0.02–$0.10 per query depending on top-k and LLM tier.
+
+## What you must not skip
+
+- **Citations.** Every claim → source. Vanta sells to auditors; no citation, no product.
+- **Evals.** If you don't mention offline+online evals in the first 10 min, you're behind.
+- **Multi-tenancy.** Say the word.
+
+## Prep reading
+
+- `tracks/genai-mle/ml-sys-design.md` in this repo — the 9-step scaffold generalized.
+- `tracks/genai-mle/resources.md` — Alireza's repo, Chip Huyen's AI Engineering (RAG chapter).
+- RAGAS docs (https://docs.ragas.io/) — the vocabulary of RAG evals.
+- Vanta's own blog (https://www.vanta.com/resources/) — read their AI product announcements before the round.

--- a/company-tags/vanta/phone-screen.md
+++ b/company-tags/vanta/phone-screen.md
@@ -1,0 +1,91 @@
+# Vanta Phone Screen — Strategy & Problems
+
+- **Duration:** ~60 minutes.
+- **Environment:** CoderPad. Some candidates reported running locally instead (`python solution.py < input.txt`) — have a local Python env warm.
+- **Structure:** 2 problems (Q1 + Q2 flavor). Q1 is a warmup; Q2 is a follow-up that reuses the data model.
+- **Interviewer style:** quiet, slow to respond. You drive the discussion, verbalize your plan, ask clarifying questions.
+
+## Time budget (60 min)
+
+| Minute | What |
+|---|---|
+| 0–3 | Intros, high-level "tell me about yourself" |
+| 3–8 | Clarify Q1 requirements — input format, output format, edge cases, expected complexity |
+| 8–25 | Code Q1. Walk through 1 example before hitting "run". |
+| 25–30 | Run Q1, verify output. Fix bugs if any. |
+| 30–35 | Q2 setup — this is when you learn the follow-up. Clarify. |
+| 35–52 | Code Q2. Reuse Q1 helpers where possible. |
+| 52–58 | Test Q2, verify. |
+| 58–60 | Q&A, wrap. |
+
+If you're at min 25 and still debugging Q1: **stop, tell the interviewer what's broken, ask if you can move on and come back**. Reports suggest this is a common failure mode — one small bug in Q1 sinks Q2 entirely.
+
+## Problem 1 (dominant — 5+ reports)
+
+**Task Dependency** — see [`task_dependency.py`](./task_dependency.py) and [`task_dependency_test.py`](./task_dependency_test.py).
+
+```
+class Task:
+    id: str
+    dependencies: list[str]  # ids of tasks this task depends on
+
+Q1: Given `all_tasks: list[Task]` and `targets: list[str]`,
+    return ALL dependencies of the target tasks in dependency order,
+    with no duplicates across targets.
+    (Transitive deps of every target, deduped, in topological order.)
+
+Q2: Given the same data, find all ANCESTOR tasks of a target
+    (tasks that transitively depend ON the target).
+    (Reverse graph, BFS/DFS from target.)
+```
+
+### Common bugs (from candidate reports)
+
+- Not handling shared deps between targets — dedup must be across all targets, not per target.
+- Emitting the target itself in the output. Q1 typically wants *deps only*, exclude the target. Clarify.
+- Iterating `list.append` while iterating the same list.
+- Cycle detection — the problem statement doesn't guarantee a DAG. Ask upfront: "Can I assume no cycles?"
+- Confusing "depends on" vs "ancestor" directions. Draw the arrow direction on paper before coding.
+
+## Problem 2 (backup — also multiple reports)
+
+**Employee Security Training / Group aggregation** — see [`employee_training.py`](./employee_training.py) and [`employee_training_test.py`](./employee_training_test.py).
+
+```
+class Employee:
+    id: str
+    start_day: int
+    training_days_required: int  # days after start_day by which they must complete training
+
+Q1: Given `check_day`, is the employee compliant?
+    If not, how many days overdue?
+    Overdue = check_day - (start_day + training_days_required), or 0 if compliant.
+
+Q2: Employees are in a TREE of groups:
+    groups: dict[group_id, list[group_id]]  # parent → subgroups
+    employees_by_group: dict[group_id, list[Employee]]
+
+    For every group in the tree, compute:
+        - total employee count (this group + all descendants)
+        - total overdue days (summed over all employees in this + descendants)
+```
+
+### Common bugs
+
+- Off-by-one in overdue calc. If they're due on day `S + T`, is `check_day = S + T` compliant or not? **Ask.**
+- Q2: recomputing subtree state per group instead of caching (O(n²) instead of O(n)).
+- Assuming the tree has a single root — the problem may have a forest. Ask.
+- Missing groups with no direct employees but with subgroups.
+
+## What NOT to spend time on
+
+- Fancy Python (dataclasses, dunder methods) — plain dict + list is fine.
+- Reading a file. Unless the interviewer explicitly asks, take the input as a Python literal in the same file.
+- Comments beyond one-liners. The interviewer will read the code as you write it.
+
+## Post-mortem template (fill after your drill)
+
+- Q1 finished at min ___ / expected ~25. Bugs? ___
+- Q2 finished at min ___ / expected ~52. Bugs? ___
+- Which clarifying question would have saved you time?
+- What did you not verbalize that you should have?

--- a/company-tags/vanta/phone-screen.md
+++ b/company-tags/vanta/phone-screen.md
@@ -70,12 +70,30 @@ Q2: Employees are in a TREE of groups:
         - total overdue days (summed over all employees in this + descendants)
 ```
 
+### Clarifying questions to ask BEFORE coding (script these)
+
+Ask these in the first ~90 seconds. Every one has bitten a candidate on 1p3a.
+
+**Data model:**
+1. **Completion field?** *"Do employees have a `trained_day` field, or is the input pre-filtered to employees who haven't completed training?"* — Variant A has no completion field (if they're in the list, they're not done). Variant B has `trained_day` and Alice who finished on day 25 is compliant even at `check_day = 50`. The overdue rule differs.
+2. **`int` days or actual `date` objects?** Older reports use ints (`joined_day`, `check_day` as day counters). Newer reports use `datetime.date`. Ask — ints are simpler; if dates, use `(check_day - due_date).days`.
+3. **Boundary: `check_day == due_day` — compliant or overdue?** Off-by-one that trips ~1 in 3 candidates. Confirm the convention out loud.
+4. **Training-not-yet-started employees** — if `check_day < start_day`, is that valid input? (Usually treat as compliant, but confirm.)
+
+**Q2 tree structure:**
+5. **Signature — interviewer WON'T give you one for Q2.** Announce yours: *"I'll take `groups: dict[str, list[str]]`, `employees_by_group: dict[str, list[Employee]]`, `check_day: int`, and return `dict[str, GroupStats]`. Sound right?"*
+6. **Single root or forest?** Vanta's real product is per-tenant so it's one root, but the abstract prompt often doesn't say. Ask — infer roots vs accept `root: str` param.
+7. **Can internal (non-leaf) groups have direct employees?** *Answer is yes* — the VP of Engineering is directly on "eng", not on any sub-team. Confirm anyway; the code is the same either way but the interviewer wants to hear you think about it.
+8. **Cycle guarantee?** *"Is `groups` guaranteed to be a tree — no cycles, each group has at most one parent?"* If not, you need a `visited` set.
+9. **Groups referenced only as children** — a group that appears in some parent's child list but has no entry in `groups` or `employees_by_group`. Should it appear in the output with `GroupStats(0, 0)`? (Yes — every referenced group gets a row.)
+
 ### Common bugs
 
-- Off-by-one in overdue calc. If they're due on day `S + T`, is `check_day = S + T` compliant or not? **Ask.**
+- Off-by-one in overdue calc. If they're due on day `S + T`, is `check_day = S + T` compliant or not? **Ask (see #3 above).**
 - Q2: recomputing subtree state per group instead of caching (O(n²) instead of O(n)).
-- Assuming the tree has a single root — the problem may have a forest. Ask.
-- Missing groups with no direct employees but with subgroups.
+- Assuming the tree has a single root — the problem may have a forest. Ask (#6).
+- Missing groups with no direct employees but with subgroups (#7 / #9).
+- Forgetting to record `result[group] = stats` inside `dfs` — you'll only get the root's total instead of one entry per group.
 
 ## What NOT to spend time on
 

--- a/company-tags/vanta/python_from_cpp.md
+++ b/company-tags/vanta/python_from_cpp.md
@@ -1,0 +1,430 @@
+# Python ↔ C++ Reference (via task_dependency.{py,cpp})
+
+Companion doc for `task_dependency.py` and `task_dependency.cpp`. Same algorithm,
+two languages. Read one, glance here, know the other.
+
+Organized bottom-up: types → declarations → loops → containers → error handling
+→ then a side-by-side walk of specific chunks from the file.
+
+---
+
+## 1. Type mapping (the base layer)
+
+| Concept | Python | C++ (`using namespace std;`) |
+|---|---|---|
+| String | `str` | `string` |
+| Dynamic array | `list[T]` | `vector<T>` |
+| Hash map | `dict[K, V]` | `unordered_map<K, V>` |
+| Tree map | `dict` (ordered by insertion) | `map<K, V>` (ordered by key) |
+| Hash set | `set[T]` | `unordered_set<T>` |
+| FIFO queue | `collections.deque` | `queue<T>` |
+| Stack | `list` (`append`/`pop`) | `stack<T>` or `vector<T>` |
+| Priority queue | `heapq` (functions on a list) | `priority_queue<T>` (max-heap default) |
+| Fixed-size record | `@dataclass` / `NamedTuple` | `struct` |
+| Auto-inserting map | `defaultdict(list)` | `unordered_map<K, vector<V>>` (via `operator[]`) |
+| Counter | `collections.Counter` | `unordered_map<K, int>` (manual `++`) |
+
+**Gotcha:** Python's default `dict` and `set` are hash-based (`unordered_*` in C++).
+For ordered iteration by key, use `std::map` / `std::set` in C++.
+
+---
+
+## 2. Declarations and initialization
+
+```python
+# Python
+by_id: dict[str, Task] = {t.id: t for t in all_tasks}
+target_set: set[str] = set(targets)
+reachable: set[str] = set()
+queue: deque[str] = deque()
+```
+
+```cpp
+// C++
+unordered_map<string, const Task*> by_id;
+for (const Task& t : all_tasks) by_id[t.id] = &t;
+
+unordered_set<string> target_set(targets.begin(), targets.end());
+unordered_set<string> reachable;
+queue<string> q;
+```
+
+**Notes:**
+- Python variable annotations (`: dict[str, Task]`) are *hints*, not enforced. C++ types are real.
+- Python dict-comprehension `{k: v for x in xs}` has no direct C++ equivalent — you write a range-for loop.
+- Python's `set(iterable)` maps to the C++ range constructor `unordered_set<T>(begin, end)`.
+- In C++ we store `const Task*` (pointer) instead of `Task` (copy). Python doesn't have this dilemma — everything is a reference under the hood.
+
+---
+
+## 3. Loop syntax
+
+### Basic iteration
+```python
+for x in xs:
+    ...
+```
+```cpp
+for (const T& x : xs) { ... }
+```
+
+### With index
+```python
+for i, x in enumerate(xs):
+    ...
+```
+```cpp
+for (size_t i = 0; i < xs.size(); ++i) {
+    const T& x = xs[i];
+    ...
+}
+```
+
+### Two containers zipped
+```python
+for a, b in zip(xs, ys):
+    ...
+```
+```cpp
+for (size_t i = 0; i < xs.size(); ++i) {
+    const T& a = xs[i];
+    const U& b = ys[i];
+    ...
+}
+```
+
+### Map iteration (key + value)
+```python
+for k, v in d.items():
+    ...
+```
+```cpp
+// with auto (idiomatic):
+for (const auto& [k, v] : d) { ... }
+// without auto (explicit):
+for (const pair<const K, V>& entry : d) {
+    const K& k = entry.first;
+    const V& v = entry.second;
+    ...
+}
+```
+
+**Gotcha:** `pair<const K, V>` — the key is `const` because map keys are immutable
+once inserted. Writing `pair<K, V>` compiles but *copies* each entry.
+
+---
+
+## 4. Membership, get-or-default, remove
+
+| Op | Python | C++ |
+|---|---|---|
+| `x in s` | `x in s` | `s.count(x)` or `s.contains(x)` (C++20) |
+| `x not in s` | `x not in s` | `!s.count(x)` |
+| `d[k]` (KeyError if missing) | `d[k]` | `d.at(k)` (throws `out_of_range`) |
+| `d[k]` (auto-insert default) | `defaultdict[k]` | `d[k]` (yes — `operator[]` on maps auto-inserts) |
+| `d.get(k, default)` | `d.get(k, default)` | `d.count(k) ? d[k] : default` (no built-in) |
+| `s.add(x)` | `s.add(x)` | `s.insert(x)` |
+| `s.remove(x)` | `s.remove(x)` | `s.erase(x)` |
+
+**Gotcha in C++:** `map[k]` on a `const map` is a compile error, and on a non-const
+map with a missing `k`, it silently *creates* a default entry. Use `.at(k)` when you
+want the "throw if missing" behavior of Python's `d[k]`.
+
+---
+
+## 5. Queue / stack ops (the BFS/DFS bread-and-butter)
+
+```python
+# Python deque as BFS queue
+q = deque()
+q.append(x)          # enqueue
+node = q.popleft()   # dequeue (returns value)
+
+# Python list as DFS stack
+s = []
+s.append(x)
+node = s.pop()       # returns value
+```
+
+```cpp
+// C++ queue<T> for BFS
+queue<string> q;
+q.push(x);              // enqueue
+string node = q.front(); // peek — pop() returns void
+q.pop();                // discard front
+
+// C++ stack<T> for DFS
+stack<string> s;
+s.push(x);
+string node = s.top();  // peek — pop() returns void
+s.pop();
+
+// Or use vector<T> as an ad-hoc stack (very common):
+vector<string> s;
+s.push_back(x);
+string node = s.back();
+s.pop_back();
+```
+
+**Gotcha:** In C++, `pop()` never returns the value. Always two lines: read
+front/top, then pop. Python's `popleft()` and `pop()` return the value.
+
+---
+
+## 6. List comprehensions → range loops
+
+```python
+# Python
+result = [n for n in order if n not in target_set]
+```
+
+```cpp
+// C++ — no equivalent, just a loop:
+vector<string> result;
+for (const string& n : order) {
+    if (!target_set.count(n)) result.push_back(n);
+}
+```
+
+This is the single biggest ergonomic gap. In an interview, using comprehensions
+in Python is worth 3–5 lines of C++ per filter/transform, and it reads better.
+
+---
+
+## 7. Error handling
+
+```python
+raise KeyError(f"target {tgt!r} not found in all_tasks")
+
+try:
+    ...
+except KeyError as e:
+    ...
+```
+
+```cpp
+throw runtime_error("target not found in all_tasks: " + tgt);
+
+try {
+    ...
+} catch (const runtime_error& e) {
+    ...
+}
+```
+
+**Gotcha:** Python has typed exceptions with a specific hierarchy. C++ exceptions
+are just types you inherit from `std::exception`. In interview code, one-off
+`runtime_error` for anything unexpected is fine.
+
+---
+
+## 8. Side-by-side: pass 1 of the optimized Q1
+
+This is the core of the algorithm — multi-source BFS building the reachable set.
+
+**Python (`task_dependency.py:105–116`):**
+```python
+reachable: set[str] = set()
+queue: deque[str] = deque()
+for tgt in targets:
+    for dep in by_id[tgt].dependencies:
+        if dep not in reachable:
+            reachable.add(dep)
+            queue.append(dep)
+while queue:
+    node = queue.popleft()
+    for dep in by_id[node].dependencies:
+        if dep not in reachable:
+            reachable.add(dep)
+            queue.append(dep)
+```
+
+**C++ (`task_dependency.cpp` pass 1 of `dependencies_of_targets`):**
+```cpp
+unordered_set<string> reachable;
+queue<string> q;
+for (const string& tgt : targets) {
+    for (const string& dep : by_id[tgt]->dependencies) {
+        if (!reachable.count(dep)) {
+            reachable.insert(dep);
+            q.push(dep);
+        }
+    }
+}
+while (!q.empty()) {
+    string node = q.front();
+    q.pop();
+    for (const string& dep : by_id[node]->dependencies) {
+        if (!reachable.count(dep)) {
+            reachable.insert(dep);
+            q.push(dep);
+        }
+    }
+}
+```
+
+**Line-by-line diff:**
+
+| Python | C++ | Note |
+|---|---|---|
+| `set()` | `unordered_set<string>` (default ctor) | Hash set |
+| `deque()` | `queue<string>` (default ctor) | Plain FIFO |
+| `for tgt in targets:` | `for (const string& tgt : targets)` | Range-for |
+| `by_id[tgt].dependencies` | `by_id[tgt]->dependencies` | `->` because pointer |
+| `dep not in reachable` | `!reachable.count(dep)` | Python is briefer |
+| `reachable.add(dep)` | `reachable.insert(dep)` | Method name diff |
+| `queue.append(dep)` | `q.push(dep)` | Method name diff |
+| `while queue:` | `while (!q.empty())` | Python: empty containers are falsy |
+| `queue.popleft()` | `string node = q.front(); q.pop();` | Two-step in C++ |
+
+---
+
+## 9. Side-by-side: pass 2 (Kahn's topo sort)
+
+**Python (`task_dependency.py:119–132`):**
+```python
+reverse_adj: dict[str, list[str]] = defaultdict(list)
+in_degree: dict[str, int] = {node: 0 for node in reachable}
+for node in reachable:
+    for dep in by_id[node].dependencies:
+        if dep in reachable:
+            reverse_adj[dep].append(node)
+            in_degree[node] += 1
+
+queue = deque(n for n, d in in_degree.items() if d == 0)
+order: list[str] = []
+while queue:
+    node = queue.popleft()
+    order.append(node)
+    for dependent in reverse_adj[node]:
+        in_degree[dependent] -= 1
+        if in_degree[dependent] == 0:
+            queue.append(dependent)
+```
+
+**C++ (`task_dependency.cpp` pass 2 of `dependencies_of_targets`):**
+```cpp
+unordered_map<string, vector<string>> reverse_adj;
+unordered_map<string, int> in_degree;
+for (const string& node : reachable) in_degree[node] = 0;
+for (const string& node : reachable) {
+    for (const string& dep : by_id[node]->dependencies) {
+        if (reachable.count(dep)) {
+            reverse_adj[dep].push_back(node);
+            in_degree[node] += 1;
+        }
+    }
+}
+
+queue<string> topo_q;
+for (const pair<const string, int>& entry : in_degree) {
+    if (entry.second == 0) topo_q.push(entry.first);
+}
+vector<string> order;
+while (!topo_q.empty()) {
+    string node = topo_q.front();
+    topo_q.pop();
+    order.push_back(node);
+    for (const string& dependent : reverse_adj[node]) {
+        if (--in_degree[dependent] == 0) topo_q.push(dependent);
+    }
+}
+```
+
+**Interesting bits:**
+
+| Python | C++ | Note |
+|---|---|---|
+| `defaultdict(list)` | `unordered_map<string, vector<string>>` | C++ `operator[]` auto-inserts default-constructed `vector` |
+| `{node: 0 for node in reachable}` | separate loop `for ... in_degree[node] = 0;` | No dict comprehension in C++ |
+| `deque(n for n, d in items if d == 0)` | separate loop + `push` | No generator + range constructor for `queue` |
+| `n for n, d in ...` | `for (const pair<const string, int>& entry : ...)` | Structured binding needs `auto` |
+| `in_degree[dep] -= 1; if ... == 0` | `if (--in_degree[dep] == 0)` | C++ pre-decrement expression is cheeky but common |
+
+---
+
+## 10. Python idioms to actively use in interviews
+
+These aren't in the C++ file because C++ doesn't have equivalents (or they're
+ugly). Learn these — they're what makes Python interview code short:
+
+```python
+# 1. List/set/dict comprehensions
+squares = [x*x for x in nums]
+even_squares = [x*x for x in nums if x % 2 == 0]
+lookup = {v: k for k, v in d.items()}
+seen = {x for x in xs}
+
+# 2. Tuple unpacking (multiple returns, swaps, enumerate/zip)
+a, b = 1, 2
+a, b = b, a               # swap without temp
+first, *rest = [1, 2, 3]  # rest = [2, 3]
+
+# 3. Chained comparisons
+if 0 <= i < len(arr):
+    ...
+
+# 4. any() / all() / sum() with generators
+if any(x < 0 for x in xs): ...
+total = sum(x*2 for x in xs)
+
+# 5. sorted / sort with key=
+sorted(words, key=len)
+sorted(pairs, key=lambda p: (p[1], -p[0]))  # sort by 2nd asc, 1st desc
+
+# 6. enumerate / zip
+for i, x in enumerate(xs): ...
+for a, b in zip(xs, ys): ...
+
+# 7. Slicing (no equivalent in C++)
+arr[::-1]     # reverse
+arr[i:j]      # subarray (view-like)
+arr[::2]      # every other element
+
+# 8. collections shortcuts
+from collections import defaultdict, Counter, deque
+counts = Counter("hello")   # {'h':1,'e':1,'l':2,'o':1}
+adj = defaultdict(list)     # adj[k].append(x) works without init
+
+# 9. String tricks
+",".join(strs)              # C++: manual loop with separator
+s.split()                   # split on whitespace
+s.startswith("foo")
+"".join(reversed(s))
+
+# 10. heapq for priority queue (min-heap by default)
+import heapq
+heap = []
+heapq.heappush(heap, 3)
+smallest = heapq.heappop(heap)
+```
+
+---
+
+## 11. Suggested workflow to internalize
+
+1. Open both files side-by-side in your IDE.
+2. Pick one function (`ancestors_of_target` is the smallest — start there).
+3. Cover the Python; try to translate the C++ back to Python from memory.
+4. Uncover, diff. Note what surprised you.
+5. Move to `dependencies_of_targets` (harder — two passes).
+6. When you can do both without peeking, move to the "idioms to use" section
+   above and drill 2–3 problems using them (Course Schedule, Clone Graph,
+   Word Ladder — all graph problems that reuse the same patterns).
+
+---
+
+## 12. Interview-day cheat: what to remember under pressure
+
+If your brain freezes and you need to code fast, these are the muscle-memory
+substitutions from C++:
+
+- `vector<X> v` → `v = []`
+- `unordered_map<K,V> m` → `m = {}`
+- `unordered_set<K> s` → `s = set()`
+- `queue<X> q; q.push(x); q.pop()` → `q = deque(); q.append(x); q.popleft()`
+- `stack<X> s; s.push(x); s.pop()` → `s = []; s.append(x); s.pop()`
+- Adjacency list `unordered_map<K, vector<V>>` → `adj = defaultdict(list)`
+- BFS visited set → same `visited = set()`, `visited.add(x)`, `x in visited`
+- Loop range `for (int i = 0; i < n; ++i)` → `for i in range(n):`
+- Loop with index `for (size_t i = 0; i < v.size(); ++i)` → `for i, x in enumerate(v):`

--- a/company-tags/vanta/task_dependency.cpp
+++ b/company-tags/vanta/task_dependency.cpp
@@ -1,0 +1,284 @@
+// C++ mirror of task_dependency.py — same algorithms, structured the same way,
+// so you can diff them mentally to learn Python idioms coming from C++.
+//
+// Python  ↔  C++ cheat sheet used below (with `using namespace std;` in effect):
+//   list[T]                         vector<T>
+//   dict[K, V]                      unordered_map<K, V>
+//   set[T]                          unordered_set<T>
+//   deque[T]  (used as FIFO)        queue<T>            // plain FIFO — one end only
+//   defaultdict(list)               unordered_map<K, vector<V>>
+//                                     (operator[] auto-inserts a default-constructed value,
+//                                      same as defaultdict semantics)
+//   @dataclass                      plain struct with public fields
+//   x in s                          s.count(x)                    (or s.contains(x) in C++20)
+//   for x in xs                     for (const T& x : xs)
+//   for k, v in d.items()           iterate as pair<const K, V>; use .first / .second
+//   raise KeyError("...")           throw runtime_error("...")
+//   [n for n in xs if pred(n)]      range loop + push_back
+//   set(xs)                         unordered_set<T>(xs.begin(), xs.end())
+//   queue.append(x)                 q.push(x)
+//   queue.popleft()                 t = q.front(); q.pop();       // two steps, pop() returns void
+//
+// Note: this file uses fully explicit types (no `auto`) to keep the C++↔Python
+// mapping as legible as possible. In real C++ you'd lean on `auto` and structured
+// bindings for the same loops.
+//
+// Complexity is identical to the Python version:
+//   dependencies_of_targets_brute: O(k*(V+E)) reachability + O(V+E) topo
+//   dependencies_of_targets:       O(V+E) total
+//   ancestors_of_target:           O(V+E)
+
+#include <iostream>
+#include <queue>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+using namespace std;
+
+struct Task {
+    string id;
+    vector<string> dependencies;
+};
+
+
+// ---------- Q1 (brute force): per-target reachability + topo sort ----------
+
+vector<string> dependencies_of_targets_brute(
+    const vector<Task>& all_tasks,
+    const vector<string>& targets
+) {
+    // by_id: dict[str, Task*] — pointer avoids copying the Task; the vector owns storage.
+    unordered_map<string, const Task*> by_id;
+    for (const Task& t : all_tasks) by_id[t.id] = &t;
+
+    unordered_set<string> target_set(targets.begin(), targets.end());
+    for (const string& tgt : targets) {
+        if (by_id.find(tgt) == by_id.end()) {
+            throw runtime_error("target not found in all_tasks: " + tgt);
+        }
+    }
+
+    // Pass 1: one BFS *per target*, fresh visited set each time, then union.
+    // Wasteful when targets share deps — same subgraph gets walked more than once.
+    unordered_set<string> reachable;
+    for (const string& tgt : targets) {
+        unordered_set<string> per_target_seen;
+        queue<string> q;
+        for (const string& dep : by_id[tgt]->dependencies) {
+            if (!per_target_seen.count(dep)) {
+                per_target_seen.insert(dep);
+                q.push(dep);
+            }
+        }
+        while (!q.empty()) {
+            string node = q.front();
+            q.pop();
+            for (const string& dep : by_id[node]->dependencies) {
+                if (!per_target_seen.count(dep)) {
+                    per_target_seen.insert(dep);
+                    q.push(dep);
+                }
+            }
+        }
+        for (const string& n : per_target_seen) reachable.insert(n);
+    }
+
+    // Pass 2: Kahn's topo sort restricted to `reachable`.
+    unordered_map<string, vector<string>> reverse_adj;
+    unordered_map<string, int> in_degree;
+    for (const string& node : reachable) in_degree[node] = 0;
+    for (const string& node : reachable) {
+        for (const string& dep : by_id[node]->dependencies) {
+            if (reachable.count(dep)) {
+                reverse_adj[dep].push_back(node);
+                in_degree[node] += 1;
+            }
+        }
+    }
+
+    queue<string> q;
+    for (const pair<const string, int>& entry : in_degree) {
+        if (entry.second == 0) q.push(entry.first);
+    }
+    vector<string> order;
+    while (!q.empty()) {
+        string node = q.front();
+        q.pop();
+        order.push_back(node);
+        for (const string& dependent : reverse_adj[node]) {
+            if (--in_degree[dependent] == 0) q.push(dependent);
+        }
+    }
+
+    if (order.size() != reachable.size()) {
+        throw runtime_error("cycle detected in dependency graph");
+    }
+
+    vector<string> result;
+    for (const string& n : order) {
+        if (!target_set.count(n)) result.push_back(n);
+    }
+    return result;
+}
+
+
+// ---------- Q1 (optimized): multi-source BFS with shared visited set ----------
+
+vector<string> dependencies_of_targets(
+    const vector<Task>& all_tasks,
+    const vector<string>& targets
+) {
+    unordered_map<string, const Task*> by_id;
+    for (const Task& t : all_tasks) by_id[t.id] = &t;
+
+    unordered_set<string> target_set(targets.begin(), targets.end());
+    for (const string& tgt : targets) {
+        if (by_id.find(tgt) == by_id.end()) {
+            throw runtime_error("target not found in all_tasks: " + tgt);
+        }
+    }
+
+    // Pass 1: multi-source BFS. `reachable` is shared across all targets, so
+    // each node is enqueued at most once regardless of how many targets reach it.
+    unordered_set<string> reachable;
+    queue<string> q;
+    for (const string& tgt : targets) {
+        for (const string& dep : by_id[tgt]->dependencies) {
+            if (!reachable.count(dep)) {
+                reachable.insert(dep);
+                q.push(dep);
+            }
+        }
+    }
+    while (!q.empty()) {
+        string node = q.front();
+        q.pop();
+        for (const string& dep : by_id[node]->dependencies) {
+            if (!reachable.count(dep)) {
+                reachable.insert(dep);
+                q.push(dep);
+            }
+        }
+    }
+
+    // Pass 2: Kahn's topo sort restricted to `reachable`. Identical to brute version.
+    unordered_map<string, vector<string>> reverse_adj;
+    unordered_map<string, int> in_degree;
+    for (const string& node : reachable) in_degree[node] = 0;
+    for (const string& node : reachable) {
+        for (const string& dep : by_id[node]->dependencies) {
+            if (reachable.count(dep)) {
+                reverse_adj[dep].push_back(node);
+                in_degree[node] += 1;
+            }
+        }
+    }
+
+    queue<string> topo_q;
+    for (const pair<const string, int>& entry : in_degree) {
+        if (entry.second == 0) topo_q.push(entry.first);
+    }
+    vector<string> order;
+    while (!topo_q.empty()) {
+        string node = topo_q.front();
+        topo_q.pop();
+        order.push_back(node);
+        for (const string& dependent : reverse_adj[node]) {
+            if (--in_degree[dependent] == 0) topo_q.push(dependent);
+        }
+    }
+
+    if (order.size() != reachable.size()) {
+        throw runtime_error("cycle detected in dependency graph");
+    }
+
+    vector<string> result;
+    for (const string& n : order) {
+        if (!target_set.count(n)) result.push_back(n);
+    }
+    return result;
+}
+
+
+// ---------- Q2: transitive ancestors of a single target ----------
+
+vector<string> ancestors_of_target(
+    const vector<Task>& all_tasks,
+    const string& target
+) {
+    unordered_map<string, const Task*> by_id;
+    for (const Task& t : all_tasks) by_id[t.id] = &t;
+    if (by_id.find(target) == by_id.end()) {
+        throw runtime_error("target not found in all_tasks: " + target);
+    }
+
+    // Build reverse adjacency: dep → list of things that depend on it.
+    unordered_map<string, vector<string>> reverse_adj;
+    for (const Task& task : all_tasks) {
+        for (const string& dep : task.dependencies) {
+            reverse_adj[dep].push_back(task.id);
+        }
+    }
+
+    vector<string> ancestors;
+    unordered_set<string> seen = {target};
+    queue<string> q;
+    q.push(target);
+    while (!q.empty()) {
+        string node = q.front();
+        q.pop();
+        for (const string& parent : reverse_adj[node]) {
+            if (!seen.count(parent)) {
+                seen.insert(parent);
+                ancestors.push_back(parent);
+                q.push(parent);
+            }
+        }
+    }
+    return ancestors;
+}
+
+
+// ---------- demo ----------
+
+static void print_vec(const string& label, const vector<string>& v) {
+    cout << label << ": [";
+    for (size_t i = 0; i < v.size(); ++i) {
+        cout << "'" << v[i] << "'";
+        if (i + 1 < v.size()) cout << ", ";
+    }
+    cout << "]\n";
+}
+
+int main() {
+    //
+    //   A ──┐
+    //   B ──┤─→ D ─→ F
+    //   C ──┘       ↑
+    //          E ───┘
+    //
+    vector<Task> tasks = {
+        {"A", {}},
+        {"B", {}},
+        {"C", {}},
+        {"D", {"A", "B", "C"}},
+        {"E", {}},
+        {"F", {"D", "E"}},
+    };
+
+    print_vec("Q1 brute  deps of [F]   ", dependencies_of_targets_brute(tasks, {"F"}));
+    print_vec("Q1 opt    deps of [F]   ", dependencies_of_targets(tasks, {"F"}));
+    print_vec("Q1 brute  deps of [D,E] ", dependencies_of_targets_brute(tasks, {"D", "E"}));
+    print_vec("Q1 opt    deps of [D,E] ", dependencies_of_targets(tasks, {"D", "E"}));
+    print_vec("Q1 brute  deps of [F,D] ", dependencies_of_targets_brute(tasks, {"F", "D"}));
+    print_vec("Q1 opt    deps of [F,D] ", dependencies_of_targets(tasks, {"F", "D"}));
+    print_vec("Q2  ancestors of A      ", ancestors_of_target(tasks, "A"));
+    print_vec("Q2  ancestors of E      ", ancestors_of_target(tasks, "E"));
+    print_vec("Q2  ancestors of F      ", ancestors_of_target(tasks, "F"));
+
+    return 0;
+}

--- a/company-tags/vanta/task_dependency.cpp
+++ b/company-tags/vanta/task_dependency.cpp
@@ -24,9 +24,8 @@
 // bindings for the same loops.
 //
 // Complexity is identical to the Python version:
-//   dependencies_of_targets_brute: O(k*(V+E)) reachability + O(V+E) topo
-//   dependencies_of_targets:       O(V+E) total
-//   ancestors_of_target:           O(V+E)
+//   dependencies_of_targets:  O(V+E) total
+//   ancestors_of_target:      O(V+E)
 
 #include <iostream>
 #include <queue>
@@ -45,88 +44,7 @@ struct Task {
 };
 
 
-// ---------- Q1 (brute force): per-target reachability + topo sort ----------
-
-vector<string> dependencies_of_targets_brute(
-    const vector<Task>& all_tasks,
-    const vector<string>& targets
-) {
-    // by_id: dict[str, Task*] — pointer avoids copying the Task; the vector owns storage.
-    unordered_map<string, const Task*> by_id;
-    for (const Task& t : all_tasks) by_id[t.id] = &t;
-
-    unordered_set<string> target_set(targets.begin(), targets.end());
-    for (const string& tgt : targets) {
-        if (by_id.find(tgt) == by_id.end()) {
-            throw runtime_error("target not found in all_tasks: " + tgt);
-        }
-    }
-
-    // Pass 1: one BFS *per target*, fresh visited set each time, then union.
-    // Wasteful when targets share deps — same subgraph gets walked more than once.
-    unordered_set<string> reachable;
-    for (const string& tgt : targets) {
-        unordered_set<string> per_target_seen;
-        queue<string> q;
-        for (const string& dep : by_id[tgt]->dependencies) {
-            if (!per_target_seen.count(dep)) {
-                per_target_seen.insert(dep);
-                q.push(dep);
-            }
-        }
-        while (!q.empty()) {
-            string node = q.front();
-            q.pop();
-            for (const string& dep : by_id[node]->dependencies) {
-                if (!per_target_seen.count(dep)) {
-                    per_target_seen.insert(dep);
-                    q.push(dep);
-                }
-            }
-        }
-        for (const string& n : per_target_seen) reachable.insert(n);
-    }
-
-    // Pass 2: Kahn's topo sort restricted to `reachable`.
-    unordered_map<string, vector<string>> reverse_adj;
-    unordered_map<string, int> in_degree;
-    for (const string& node : reachable) in_degree[node] = 0;
-    for (const string& node : reachable) {
-        for (const string& dep : by_id[node]->dependencies) {
-            if (reachable.count(dep)) {
-                reverse_adj[dep].push_back(node);
-                in_degree[node] += 1;
-            }
-        }
-    }
-
-    queue<string> q;
-    for (const pair<const string, int>& entry : in_degree) {
-        if (entry.second == 0) q.push(entry.first);
-    }
-    vector<string> order;
-    while (!q.empty()) {
-        string node = q.front();
-        q.pop();
-        order.push_back(node);
-        for (const string& dependent : reverse_adj[node]) {
-            if (--in_degree[dependent] == 0) q.push(dependent);
-        }
-    }
-
-    if (order.size() != reachable.size()) {
-        throw runtime_error("cycle detected in dependency graph");
-    }
-
-    vector<string> result;
-    for (const string& n : order) {
-        if (!target_set.count(n)) result.push_back(n);
-    }
-    return result;
-}
-
-
-// ---------- Q1 (optimized): multi-source BFS with shared visited set ----------
+// ---------- Q1: multi-source BFS with shared visited set + Kahn's topo sort ----------
 
 vector<string> dependencies_of_targets(
     const vector<Task>& all_tasks,
@@ -165,7 +83,7 @@ vector<string> dependencies_of_targets(
         }
     }
 
-    // Pass 2: Kahn's topo sort restricted to `reachable`. Identical to brute version.
+    // Pass 2: Kahn's topo sort restricted to `reachable`.
     unordered_map<string, vector<string>> reverse_adj;
     unordered_map<string, int> in_degree;
     for (const string& node : reachable) in_degree[node] = 0;
@@ -270,15 +188,12 @@ int main() {
         {"F", {"D", "E"}},
     };
 
-    print_vec("Q1 brute  deps of [F]   ", dependencies_of_targets_brute(tasks, {"F"}));
-    print_vec("Q1 opt    deps of [F]   ", dependencies_of_targets(tasks, {"F"}));
-    print_vec("Q1 brute  deps of [D,E] ", dependencies_of_targets_brute(tasks, {"D", "E"}));
-    print_vec("Q1 opt    deps of [D,E] ", dependencies_of_targets(tasks, {"D", "E"}));
-    print_vec("Q1 brute  deps of [F,D] ", dependencies_of_targets_brute(tasks, {"F", "D"}));
-    print_vec("Q1 opt    deps of [F,D] ", dependencies_of_targets(tasks, {"F", "D"}));
-    print_vec("Q2  ancestors of A      ", ancestors_of_target(tasks, "A"));
-    print_vec("Q2  ancestors of E      ", ancestors_of_target(tasks, "E"));
-    print_vec("Q2  ancestors of F      ", ancestors_of_target(tasks, "F"));
+    print_vec("Q1 deps of [F]     ", dependencies_of_targets(tasks, {"F"}));
+    print_vec("Q1 deps of [D, E]  ", dependencies_of_targets(tasks, {"D", "E"}));
+    print_vec("Q1 deps of [F, D]  ", dependencies_of_targets(tasks, {"F", "D"}));
+    print_vec("Q2 ancestors of A  ", ancestors_of_target(tasks, "A"));
+    print_vec("Q2 ancestors of E  ", ancestors_of_target(tasks, "E"));
+    print_vec("Q2 ancestors of F  ", ancestors_of_target(tasks, "F"));
 
     return 0;
 }

--- a/company-tags/vanta/task_dependency.py
+++ b/company-tags/vanta/task_dependency.py
@@ -1,0 +1,138 @@
+"""
+Vanta phone screen: Task Dependency.
+
+Q1: Given all tasks + a list of target ids, return every task that any target
+    depends on (transitively), in dependency order (a dep must appear before
+    any task that depends on it), deduped across targets. Excludes the target
+    ids themselves.
+
+Q2: Given the same data + a single target id, return every task that
+    transitively depends ON the target (its "ancestors").
+
+Assumptions to CLARIFY with the interviewer before coding:
+    - Is the graph guaranteed to be a DAG? (Defensively raise on cycle.)
+    - For Q1, does the output include the target ids? (This impl excludes them.)
+    - "Dependency order" = a topological order of the dep subgraph. Any valid
+      topo order is accepted unless a specific tiebreak is requested.
+
+Complexity: O(V + E) for both Q1 and Q2.
+"""
+
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Task:
+    id: str
+    dependencies: list[str] = field(default_factory=list)
+
+
+# ---------- Q1: transitive dependencies of a set of targets ----------
+
+def dependencies_of_targets(all_tasks: list[Task], targets: list[str]) -> list[str]:
+    by_id: dict[str, Task] = {t.id: t for t in all_tasks}
+    target_set: set[str] = set(targets)
+    for tgt in targets:
+        if tgt not in by_id:
+            raise KeyError(f"target {tgt!r} not found in all_tasks")
+
+    # 1. Reachable-as-dependency set — DFS on dep edges from every target.
+    #    A target can itself be reachable as a dep of another target
+    #    (targets = [F, D], F depends on D). We collect all reachable ids
+    #    here — including targets that surface as deps — because the topo
+    #    sort needs the full induced subgraph. We drop targets from the
+    #    final output at step 3.
+    reachable: set[str] = set()
+    stack: list[str] = []
+    for tgt in targets:
+        for dep in by_id[tgt].dependencies:
+            if dep not in reachable:
+                reachable.add(dep)
+                stack.append(dep)
+    while stack:
+        node = stack.pop()
+        for dep in by_id[node].dependencies:
+            if dep not in reachable:
+                reachable.add(dep)
+                stack.append(dep)
+
+    # 2. Topological sort restricted to `reachable` via Kahn's algorithm.
+    #    Edge convention: dep → dependent (so a dep is emitted before what depends on it).
+    reverse_adj: dict[str, list[str]] = defaultdict(list)
+    in_degree: dict[str, int] = {node: 0 for node in reachable}
+    for node in reachable:
+        for dep in by_id[node].dependencies:
+            if dep in reachable:
+                reverse_adj[dep].append(node)
+                in_degree[node] += 1
+
+    queue: deque[str] = deque(n for n, d in in_degree.items() if d == 0)
+    order: list[str] = []
+    while queue:
+        node = queue.popleft()
+        order.append(node)
+        for dependent in reverse_adj[node]:
+            in_degree[dependent] -= 1
+            if in_degree[dependent] == 0:
+                queue.append(dependent)
+
+    if len(order) != len(reachable):
+        raise ValueError("cycle detected in dependency graph")
+
+    # 3. Exclude targets from the final output. Ask the interviewer whether they
+    #    want the targets in the answer; the common Vanta framing wants "extra
+    #    work to complete before the targets", which excludes them.
+    return [n for n in order if n not in target_set]
+
+
+# ---------- Q2: transitive ancestors of a single target ----------
+
+def ancestors_of_target(all_tasks: list[Task], target: str) -> list[str]:
+    by_id: dict[str, Task] = {t.id: t for t in all_tasks}
+    if target not in by_id:
+        raise KeyError(f"target {target!r} not found in all_tasks")
+
+    reverse_adj: dict[str, list[str]] = defaultdict(list)
+    for task in all_tasks:
+        for dep in task.dependencies:
+            reverse_adj[dep].append(task.id)
+
+    ancestors: list[str] = []
+    seen: set[str] = {target}
+    queue: deque[str] = deque([target])
+    while queue:
+        node = queue.popleft()
+        for parent in reverse_adj[node]:
+            if parent not in seen:
+                seen.add(parent)
+                ancestors.append(parent)
+                queue.append(parent)
+
+    return ancestors
+
+
+# ---------- demo ----------
+
+if __name__ == "__main__":
+    #
+    #   A ──┐
+    #   B ──┤─→ D ─→ F
+    #   C ──┘       ↑
+    #          E ───┘
+    #
+    tasks = [
+        Task("A"),
+        Task("B"),
+        Task("C"),
+        Task("D", ["A", "B", "C"]),
+        Task("E"),
+        Task("F", ["D", "E"]),
+    ]
+
+    print("Q1  deps of [F]         :", dependencies_of_targets(tasks, ["F"]))
+    print("Q1  deps of [D, E]      :", dependencies_of_targets(tasks, ["D", "E"]))
+    print("Q1  deps of [F, D]      :", dependencies_of_targets(tasks, ["F", "D"]))
+    print("Q2  ancestors of A      :", ancestors_of_target(tasks, "A"))
+    print("Q2  ancestors of E      :", ancestors_of_target(tasks, "E"))
+    print("Q2  ancestors of F      :", ancestors_of_target(tasks, "F"))

--- a/company-tags/vanta/task_dependency.py
+++ b/company-tags/vanta/task_dependency.py
@@ -1,21 +1,122 @@
 """
 Vanta phone screen: Task Dependency.
 
-Q1: Given all tasks + a list of target ids, return every task that any target
-    depends on (transitively), in dependency order (a dep must appear before
-    any task that depends on it), deduped across targets. Excludes the target
-    ids themselves.
+═══════════════════════════════════════════════════════════════════════════
+                   INTERVIEW APPROACH — READ THIS FIRST
+═══════════════════════════════════════════════════════════════════════════
 
-Q2: Given the same data + a single target id, return every task that
-    transitively depends ON the target (its "ancestors").
+PROBLEMS
+--------
+Q1: Given `all_tasks` (each task has an id + list of dependency ids) and
+    `targets` (list of task ids), return every task that any target
+    transitively depends on, in a valid execution order (a dep must
+    appear before anything that depends on it). Excludes the targets
+    themselves. Deduped across targets.
 
-Assumptions to CLARIFY with the interviewer before coding:
-    - Is the graph guaranteed to be a DAG? (Defensively raise on cycle.)
-    - For Q1, does the output include the target ids? (This impl excludes them.)
-    - "Dependency order" = a topological order of the dep subgraph. Any valid
-      topo order is accepted unless a specific tiebreak is requested.
+Q2: Given the same input + a single target id, return every task that
+    transitively depends ON the target (its "ancestors" up the graph).
 
-Complexity: O(V + E) for both Q1 and Q2.
+───────────────────────────────────────────────────────────────────────────
+STEP 1 — CLARIFYING QUESTIONS (ASK 2-3 BEFORE CODING)
+───────────────────────────────────────────────────────────────────────────
+Interviewers score you on these. Jumping straight to code signals you're
+guessing. If the prompt is sparse, ask:
+
+    1. "Should the output include the target ids themselves, or only
+        their dependencies?"
+        → This impl excludes targets (common Vanta framing: "extra work
+          needed before completing the targets"). Confirm.
+
+    2. "Is the graph guaranteed to be a DAG, or should I detect cycles
+        like A depends on B and B depends on A?"
+        → If cycles possible: raise on detection.
+        → Kahn's algorithm catches them for free
+          (len(topo_order) != len(reachable_set) ⇒ cycle).
+
+    3. "Will `all_tasks` contain tasks that no target depends on —
+        unrelated islands in the graph?"
+        → Almost always yes. Those tasks MUST NOT appear in the output.
+        → This is what motivates the reachability (BFS) step.
+
+    4. "Is any valid topological order acceptable, or do you want a
+        specific tiebreak (e.g., alphabetical among equals)?"
+        → Usually any valid order. If specific, swap Kahn's queue for a heap.
+
+    5. "Can a dep id reference a task not in `all_tasks`? Duplicate ids
+        in all_tasks or in targets? Empty targets list?"
+        → Usually no on all three, but confirm — cheap questions with
+          large downside if wrong.
+
+───────────────────────────────────────────────────────────────────────────
+STEP 2 — SOLUTION PROGRESSION (narrate this out loud)
+───────────────────────────────────────────────────────────────────────────
+The interviewer scores your reasoning, not just the final code. Walk them
+through the progression:
+
+  APPROACH A — recursive post-order DFS from each target
+    def dfs(node):
+        if node in visited: return
+        visited.add(node)
+        for dep in by_id[node].dependencies:
+            dfs(dep)
+        if node not in target_set:
+            result.append(node)   # post-order → topo order for free
+    for tgt in targets: dfs(tgt)
+
+    ✓ Reachability + ordering in ONE pass (post-order emission).
+    ✗ Python recursion limit (~1000) blows up on deep chains.
+    ✗ Cycle detection needs 3-color DFS (WHITE/GRAY/BLACK).
+    Complexity: O(V + E).
+
+  APPROACH B — two-pass, per-target BFS + Kahn's  (see: dependencies_of_targets_brute)
+    Pass 1: For each target, BFS its deps into a fresh visited set. Union.
+    Pass 2: Kahn's topo sort restricted to the union.
+
+    ✓ Iterative — no recursion limit.
+    ✓ Cycle detection free from Kahn's.
+    ✗ Pass 1 re-walks shared subgraphs across targets.
+    Complexity: O(k*(V + E)) + O(V + E) where k = len(targets).
+
+  APPROACH C — two-pass, multi-source BFS + Kahn's  (see: dependencies_of_targets)
+    Pass 1: ONE BFS starting from ALL targets simultaneously, sharing a
+            single `reachable` set. Each node enqueued at most once.
+    Pass 2: Same Kahn's as B.
+
+    ✓ Every advantage of B, without the k-fold waste.
+    Complexity: O(V + E) total.
+
+Narration template:
+    "I'd start with recursive post-order DFS — clean and one-pass. But two
+     concerns: Python's recursion limit on deep chains, and cycle detection
+     is finicky (3-color). Let me switch to iterative Kahn's — that gives
+     cycle detection for free. First pass finds the reachable subgraph
+     from the targets, second pass topo-sorts it. One optimization: instead
+     of a fresh BFS per target, one multi-source BFS with a shared visited
+     set — same work regardless of overlap."
+
+───────────────────────────────────────────────────────────────────────────
+STEP 3 — MENTAL MODEL
+───────────────────────────────────────────────────────────────────────────
+The whole algorithm is a two-phase pipeline: SCOPE DOWN, then ORDER.
+
+  Phase 1 (BFS reachability): "Which tasks are we even talking about?"
+                              Prunes unrelated tasks from all_tasks so
+                              phase 2 doesn't waste work on them.
+
+  Phase 2 (Kahn's topo sort): "In what order should we run them?"
+                              Also gives cycle detection for free.
+
+Any graph problem shaped like "given a big graph + a starting set, do X
+only within reach" tends to fit this shape (Course Schedule II, Clone
+Graph, etc.). Q2 is Q1 with edges reversed — "what depends on me?" walks
+the graph backwards.
+
+COMPLEXITY
+----------
+Q1 brute:      O(k*(V+E)) reachability + O(V+E) topo = O(k*(V+E))
+Q1 optimized:  O(V + E)
+Q2:            O(V + E)
+═══════════════════════════════════════════════════════════════════════════
 """
 
 from collections import defaultdict, deque
@@ -28,37 +129,162 @@ class Task:
     dependencies: list[str] = field(default_factory=list)
 
 
-# ---------- Q1: transitive dependencies of a set of targets ----------
+# ═══════════════════════════════════════════════════════════════════════════
+# Q1 APPROACH B (brute force): per-target BFS + Kahn's topo sort
+# ═══════════════════════════════════════════════════════════════════════════
 
-def dependencies_of_targets(all_tasks: list[Task], targets: list[str]) -> list[str]:
+def dependencies_of_targets_brute(all_tasks: list[Task], targets: list[str]) -> list[str]:
+    """APPROACH B — the natural first version to code in an interview.
+
+    Intuition:
+        Two questions, two passes.
+        Q1: "Which tasks matter?"   → BFS from each target, union the results.
+        Q2: "In what order?"        → Kahn's topo sort on that subgraph.
+
+    Why not just Kahn's on all_tasks?
+        Kahn's would happily topo-sort the entire task universe, including
+        unrelated islands (tasks no target depends on). We'd have to filter
+        those out at the end — and filtering requires the reachability info
+        anyway. So we compute reachability first and prune upfront.
+
+    Why not optimal?
+        Pass 1 uses a fresh visited set per target. If F and G both depend
+        on D, D's whole subtree gets walked twice. See `dependencies_of_targets`
+        below for the fix (shared visited set).
+
+    Complexity: O(k*(V+E)) reachability + O(V+E) topo, where k = |targets|.
+    """
     by_id: dict[str, Task] = {t.id: t for t in all_tasks}
     target_set: set[str] = set(targets)
+
+    # Defensive: catch bad input at the boundary. Cheap to check, hard to debug otherwise.
     for tgt in targets:
         if tgt not in by_id:
             raise KeyError(f"target {tgt!r} not found in all_tasks")
 
-    # 1. Reachable-as-dependency set — DFS on dep edges from every target.
-    #    A target can itself be reachable as a dep of another target
-    #    (targets = [F, D], F depends on D). We collect all reachable ids
-    #    here — including targets that surface as deps — because the topo
-    #    sort needs the full induced subgraph. We drop targets from the
-    #    final output at step 3.
+    # ─── PASS 1: Reachability (per-target BFS, union results) ──────────
+    # WHY: We must know which tasks the targets transitively depend on so
+    # we can (a) prune the input for pass 2 and (b) exclude unrelated
+    # tasks from the final output.
+    #
+    # WHY per-target (not multi-source): This is the "naive" version — for
+    # each target, we run a full BFS with a fresh `per_target_seen` set.
+    # Then we union everything into `reachable`. Wasteful when targets
+    # share deps, but very easy to reason about.
     reachable: set[str] = set()
-    stack: list[str] = []
+    for tgt in targets:
+        per_target_seen: set[str] = set()
+        queue: deque[str] = deque()
+        # Seed with target's *direct* deps — not the target itself, since
+        # we want to exclude targets from the output.
+        for dep in by_id[tgt].dependencies:
+            if dep not in per_target_seen:
+                per_target_seen.add(dep)
+                queue.append(dep)
+        while queue:
+            node = queue.popleft()
+            for dep in by_id[node].dependencies:
+                if dep not in per_target_seen:
+                    per_target_seen.add(dep)
+                    queue.append(dep)
+        reachable |= per_target_seen
+
+    # ─── PASS 2: Kahn's topological sort restricted to `reachable` ─────
+    # WHY Kahn's over recursive DFS: (1) iterative → no Python stack
+    # limit; (2) built-in cycle detection via `len(order) != len(reachable)`.
+    #
+    # Edge convention: dep → dependent (so a dep is emitted before what
+    # depends on it). in_degree[X] = "how many deps X has that are still
+    # unprocessed." When in_degree[X] == 0, X's deps are all done → emit X.
+    reverse_adj: dict[str, list[str]] = defaultdict(list)
+    in_degree: dict[str, int] = {node: 0 for node in reachable}
+    for node in reachable:
+        for dep in by_id[node].dependencies:
+            if dep in reachable:  # (redundant given BFS invariant, kept for clarity)
+                reverse_adj[dep].append(node)
+                in_degree[node] += 1
+
+    queue = deque(n for n, d in in_degree.items() if d == 0)
+    order: list[str] = []
+    while queue:
+        node = queue.popleft()
+        order.append(node)
+        for dependent in reverse_adj[node]:
+            in_degree[dependent] -= 1
+            if in_degree[dependent] == 0:
+                queue.append(dependent)
+
+    # WHY this check: if a cycle exists, some nodes never reach in_degree
+    # 0, so they're never emitted. len(order) < len(reachable) is the tell.
+    if len(order) != len(reachable):
+        raise ValueError("cycle detected in dependency graph")
+
+    # ─── PASS 3 (trivial): filter out targets from the output ──────────
+    # WHY: The problem asks for "extra work needed before the targets."
+    # Targets in `reachable` (when one target depends on another) must be
+    # dropped here. Confirm this framing with the interviewer upfront.
+    return [n for n in order if n not in target_set]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Q1 APPROACH C (optimized): multi-source BFS + Kahn's topo sort
+# ═══════════════════════════════════════════════════════════════════════════
+
+def dependencies_of_targets(all_tasks: list[Task], targets: list[str]) -> list[str]:
+    """APPROACH C — the optimization to converge on if you have time.
+
+    The ONE key insight vs. brute:
+        Instead of running a fresh BFS per target, seed a single BFS queue
+        with the direct deps of EVERY target upfront and share ONE visited
+        set (`reachable`) across the whole traversal. This turns k separate
+        BFSes into one multi-source BFS. Any node reachable from multiple
+        targets gets processed exactly once.
+
+    Pass 2 (Kahn's) and pass 3 (filter) are byte-identical to brute — the
+    only diff is pass 1. That's the "diff between naive and optimized" you
+    can point at during the interview.
+
+    Complexity: O(V + E) total.
+    """
+    by_id: dict[str, Task] = {t.id: t for t in all_tasks}
+    target_set: set[str] = set(targets)
+
+    for tgt in targets:
+        if tgt not in by_id:
+            raise KeyError(f"target {tgt!r} not found in all_tasks")
+
+    # ─── PASS 1: Multi-source BFS (SHARED visited set) ─────────────────
+    # `reachable` does double duty: (a) the visited set that prevents
+    # re-processing shared subgraphs and cycles, (b) the final set of
+    # in-scope tasks that pass 2 will topo-sort.
+    #
+    # Seeding: enqueue every target's direct deps upfront (not the targets
+    # themselves — we want to exclude targets from output). Then a single
+    # BFS drains the queue. The `if dep not in reachable` guard means each
+    # node enters the queue at most once, regardless of how many paths
+    # reach it.
+    #
+    # Edge case worth mentioning: if targets = [F, D] and F depends on D,
+    # then D ends up in `reachable` (F pulls it in). Its own deps then get
+    # explored during BFS. We drop D from the final output in step 3.
+    reachable: set[str] = set()
+    queue: deque[str] = deque()
     for tgt in targets:
         for dep in by_id[tgt].dependencies:
             if dep not in reachable:
                 reachable.add(dep)
-                stack.append(dep)
-    while stack:
-        node = stack.pop()
+                queue.append(dep)
+    while queue:
+        node = queue.popleft()
         for dep in by_id[node].dependencies:
             if dep not in reachable:
                 reachable.add(dep)
-                stack.append(dep)
+                queue.append(dep)
 
-    # 2. Topological sort restricted to `reachable` via Kahn's algorithm.
-    #    Edge convention: dep → dependent (so a dep is emitted before what depends on it).
+    # ─── PASS 2: Kahn's topological sort restricted to `reachable` ─────
+    # Identical to brute. Kahn's gives us:
+    #   (1) a valid topo order (deps before dependents), and
+    #   (2) cycle detection for free.
     reverse_adj: dict[str, list[str]] = defaultdict(list)
     in_degree: dict[str, int] = {node: 0 for node in reachable}
     for node in reachable:
@@ -67,7 +293,7 @@ def dependencies_of_targets(all_tasks: list[Task], targets: list[str]) -> list[s
                 reverse_adj[dep].append(node)
                 in_degree[node] += 1
 
-    queue: deque[str] = deque(n for n, d in in_degree.items() if d == 0)
+    queue = deque(n for n, d in in_degree.items() if d == 0)
     order: list[str] = []
     while queue:
         node = queue.popleft()
@@ -80,24 +306,109 @@ def dependencies_of_targets(all_tasks: list[Task], targets: list[str]) -> list[s
     if len(order) != len(reachable):
         raise ValueError("cycle detected in dependency graph")
 
-    # 3. Exclude targets from the final output. Ask the interviewer whether they
-    #    want the targets in the answer; the common Vanta framing wants "extra
-    #    work to complete before the targets", which excludes them.
+    # ─── PASS 3: Filter targets from output ────────────────────────────
     return [n for n in order if n not in target_set]
 
 
-# ---------- Q2: transitive ancestors of a single target ----------
+# ═══════════════════════════════════════════════════════════════════════════
+# Q1 VARIANT: same problem, but INCLUDE the targets in the output
+# ═══════════════════════════════════════════════════════════════════════════
+
+def dependencies_of_targets_include(all_tasks: list[Task], targets: list[str]) -> list[str]:
+    """Variant of `dependencies_of_targets` that INCLUDES the target ids in
+    the output, in valid topo order alongside their deps.
+
+    Use this when the interviewer answers clarifying question #1 with
+    "include the targets" instead of "just their deps."
+
+    Two changes vs the exclude version:
+        1. BFS init seeds with the TARGETS THEMSELVES, not their deps.
+           (This ensures every target lands in `reachable`, including
+            targets that no other target depends on.)
+        2. No filter step at the end — return the topo order as-is.
+
+    Complexity: O(V + E) — same as the exclude version.
+    """
+    by_id: dict[str, Task] = {t.id: t for t in all_tasks}
+    for tgt in targets:
+        if tgt not in by_id:
+            raise KeyError(f"target {tgt!r} not found in all_tasks")
+
+    # PASS 1: Multi-source BFS — seed with targets THEMSELVES.
+    reachable: set[str] = set()
+    queue: deque[str] = deque()
+    for tgt in targets:
+        if tgt not in reachable:
+            reachable.add(tgt)
+            queue.append(tgt)
+    while queue:
+        node = queue.popleft()
+        for dep in by_id[node].dependencies:
+            if dep not in reachable:
+                reachable.add(dep)
+                queue.append(dep)
+
+    # PASS 2: Kahn's — identical to exclude version.
+    reverse_adj: dict[str, list[str]] = defaultdict(list)
+    in_degree: dict[str, int] = {node: 0 for node in reachable}
+    for node in reachable:
+        for dep in by_id[node].dependencies:
+            if dep in reachable:
+                reverse_adj[dep].append(node)
+                in_degree[node] += 1
+
+    queue = deque(n for n, d in in_degree.items() if d == 0)
+    order: list[str] = []
+    while queue:
+        node = queue.popleft()
+        order.append(node)
+        for dependent in reverse_adj[node]:
+            in_degree[dependent] -= 1
+            if in_degree[dependent] == 0:
+                queue.append(dependent)
+
+    if len(order) != len(reachable):
+        raise ValueError("cycle detected in dependency graph")
+
+    # PASS 3: No filter — targets are already in the topo order in the
+    # correct position (after their deps).
+    return order
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Q2: transitive ancestors of a single target
+# ═══════════════════════════════════════════════════════════════════════════
 
 def ancestors_of_target(all_tasks: list[Task], target: str) -> list[str]:
+    """Q2 is Q1 with the edges reversed.
+
+    Q1 asks: "what does target DEPEND on?" — walk forward along dep edges.
+    Q2 asks: "what DEPENDS on target?" — walk backward along dep edges.
+
+    Trick: build the REVERSE adjacency list once (`dep → list of dependents`),
+    then BFS from the target. No topo sort needed — the problem doesn't ask
+    for order among ancestors, so plain BFS discovery order is fine.
+
+    Complexity: O(V + E) — build reverse adj is O(V + E), BFS is O(V + E).
+
+    If the interviewer wants a specific order among ancestors, confirm
+    what they want (topological? alphabetical?) before coding.
+    """
     by_id: dict[str, Task] = {t.id: t for t in all_tasks}
     if target not in by_id:
         raise KeyError(f"target {target!r} not found in all_tasks")
 
+    # ─── Build reverse adjacency: dep → list of things that depend on it ─
+    # WHY: The input gives us "who I depend on" per task. To answer "who
+    # depends on ME," we need to flip the edges once and then walk normally.
     reverse_adj: dict[str, list[str]] = defaultdict(list)
     for task in all_tasks:
         for dep in task.dependencies:
             reverse_adj[dep].append(task.id)
 
+    # ─── BFS from target along the reverse edges ───────────────────────
+    # `seen` starts with target because we don't want target in the output
+    # (we're returning ancestors, which by definition excludes self).
     ancestors: list[str] = []
     seen: set[str] = {target}
     queue: deque[str] = deque([target])
@@ -112,27 +423,100 @@ def ancestors_of_target(all_tasks: list[Task], target: str) -> list[str]:
     return ancestors
 
 
-# ---------- demo ----------
+# ═══════════════════════════════════════════════════════════════════════════
+# demo — verify both Q1 versions produce valid topo orders
+# ═══════════════════════════════════════════════════════════════════════════
+
+def _validate_topo(output: list[str], tasks_by_id: dict[str, Task], expected: list[str]) -> str:
+    """Return 'PASS' if `output` (a) contains exactly the expected set of ids
+    and (b) is a valid topological order (every dep appears before its
+    dependent). Otherwise a diagnostic string.
+
+    Topo order isn't unique, so we can't string-match — we check the two
+    properties that DEFINE correctness instead.
+    """
+    if set(output) != set(expected):
+        missing = sorted(set(expected) - set(output))
+        extra = sorted(set(output) - set(expected))
+        return f"FAIL (content) — missing={missing}, extra={extra}"
+    positions = {n: i for i, n in enumerate(output)}
+    for tid in positions:
+        task = tasks_by_id.get(tid)
+        if task is None:
+            continue
+        for dep in task.dependencies:
+            if dep in positions and positions[dep] >= positions[tid]:
+                return f"FAIL (order) — {dep!r} must appear before {tid!r} in {output}"
+    return "PASS"
+
 
 if __name__ == "__main__":
+    # Fixture-driven demo. Cases live in test_fixtures.json alongside this
+    # file. The runner loads the fixture, executes each case against all
+    # three Q1 variants (brute, optimized, include) and Q2, and validates
+    # results by (a) set equality vs expected, (b) topological validity.
     #
-    #   A ──┐
-    #   B ──┤─→ D ─→ F
-    #   C ──┘       ↑
-    #          E ───┘
-    #
-    tasks = [
-        Task("A"),
-        Task("B"),
-        Task("C"),
-        Task("D", ["A", "B", "C"]),
-        Task("E"),
-        Task("F", ["D", "E"]),
-    ]
+    # Topological order is NOT unique — if A, B, C all have no deps, any
+    # order among them is valid. That's why validation checks content +
+    # topo validity, not string equality.
+    import json
+    from pathlib import Path
 
-    print("Q1  deps of [F]         :", dependencies_of_targets(tasks, ["F"]))
-    print("Q1  deps of [D, E]      :", dependencies_of_targets(tasks, ["D", "E"]))
-    print("Q1  deps of [F, D]      :", dependencies_of_targets(tasks, ["F", "D"]))
-    print("Q2  ancestors of A      :", ancestors_of_target(tasks, "A"))
-    print("Q2  ancestors of E      :", ancestors_of_target(tasks, "E"))
-    print("Q2  ancestors of F      :", ancestors_of_target(tasks, "F"))
+    fixture_path = Path(__file__).parent / "test_fixtures.json"
+    with open(fixture_path) as f:
+        fixtures = json.load(f)
+
+    total, passed = 0, 0
+
+    for graph_spec in fixtures["graphs"]:
+        print("=" * 76)
+        print(f"GRAPH: {graph_spec['name']}")
+        print(f"  {graph_spec['description']}")
+        for line in graph_spec.get("ascii_art", []):
+            print(f"  {line}")
+        print("=" * 76)
+
+        tasks = [Task(t["id"], t.get("deps", [])) for t in graph_spec["tasks"]]
+        tasks_by_id = {t.id: t for t in tasks}
+
+        for case in graph_spec.get("q1_cases", []):
+            targets = case["targets"]
+            print(f"\nQ1 targets = {targets}")
+            if case.get("notes"):
+                print(f"   notes: {case['notes']}")
+
+            for label, fn, expected in [
+                ("exclude (brute)", dependencies_of_targets_brute, case["expected_exclude"]),
+                ("exclude (opt)  ", dependencies_of_targets,       case["expected_exclude"]),
+                ("include        ", dependencies_of_targets_include, case["expected_include"]),
+            ]:
+                actual = fn(tasks, targets)
+                status = _validate_topo(actual, tasks_by_id, expected)
+                total += 1
+                if status == "PASS":
+                    passed += 1
+                print(f"   {label}: {actual}  [{status}]")
+
+        for case in graph_spec.get("q2_cases", []):
+            target = case["target"]
+            actual = ancestors_of_target(tasks, target)
+            expected = case["expected_ancestors"]
+            # Q2 doesn't require topo order — the problem statement doesn't
+            # specify an order among ancestors. We validate set equality only.
+            if set(actual) == set(expected):
+                status = "PASS"
+                passed += 1
+            else:
+                missing = sorted(set(expected) - set(actual))
+                extra = sorted(set(actual) - set(expected))
+                status = f"FAIL — missing={missing}, extra={extra}"
+            total += 1
+            print(f"\nQ2 target = {target!r}")
+            if case.get("notes"):
+                print(f"   notes: {case['notes']}")
+            print(f"   ancestors: {actual}  [{status}]")
+
+    print()
+    print("=" * 76)
+    print(f"RESULTS: {passed}/{total} passed")
+    print("=" * 76)

--- a/company-tags/vanta/task_dependency.py
+++ b/company-tags/vanta/task_dependency.py
@@ -38,14 +38,32 @@ guessing. If the prompt is sparse, ask:
         → Almost always yes. Those tasks MUST NOT appear in the output.
         → This is what motivates the reachability (BFS) step.
 
-    4. "Is any valid topological order acceptable, or do you want a
-        specific tiebreak (e.g., alphabetical among equals)?"
-        → Usually any valid order. If specific, swap Kahn's queue for a heap.
+    4. "For tasks at the same dependency level — say D and G both depend
+        on A, B, C but neither depends on the other — do you care about
+        their relative order in the output? Or is any valid topological
+        order fine?"
+        → Ask this BEFORE coding. Topo sort is not unique; independent
+          nodes can appear in ANY order. If the interviewer doesn't care,
+          say so out loud and move on. If they want a specific tiebreak
+          (usually alphabetical), swap Kahn's queue for a min-heap
+          (O((V+E) log V) instead of O(V+E)) — plan for that upfront so
+          you don't have to refactor midway through.
+        → Also flag: independent leaf nodes {A, B, C} can appear in any
+          order among themselves for the same reason.
 
-    5. "Can a dep id reference a task not in `all_tasks`? Duplicate ids
-        in all_tasks or in targets? Empty targets list?"
-        → Usually no on all three, but confirm — cheap questions with
-          large downside if wrong.
+    5. "Can `targets` contain duplicates? (e.g., ['D', 'F', 'D'])"
+        → If yes: the BFS seeding loop needs an `if tgt not in reachable`
+          guard to avoid enqueueing the same target twice. Without the
+          guard, correctness is unaffected (the inner visited check
+          catches everything) but you waste one queue pop per duplicate.
+        → If the interviewer says "assume no duplicates," the guard is
+          dead code and can be removed.
+
+    6. "Can a dep id reference a task not in `all_tasks`? Empty targets
+        list? Duplicate ids in `all_tasks`?"
+        → Usually no on all three, but ask — cheap to check, large
+          downside if wrong. Empty targets should return []; missing
+          deps should probably raise (see the KeyError guard).
 
 ───────────────────────────────────────────────────────────────────────────
 STEP 2 — SOLUTION PROGRESSION (narrate this out loud)
@@ -53,7 +71,7 @@ STEP 2 — SOLUTION PROGRESSION (narrate this out loud)
 The interviewer scores your reasoning, not just the final code. Walk them
 through the progression:
 
-  APPROACH A — recursive post-order DFS from each target
+  APPROACH A — recursive post-order DFS from each target (naive starting point)
     def dfs(node):
         if node in visited: return
         visited.add(node)
@@ -64,35 +82,29 @@ through the progression:
     for tgt in targets: dfs(tgt)
 
     ✓ Reachability + ordering in ONE pass (post-order emission).
-    ✗ Python recursion limit (~1000) blows up on deep chains.
+    ✓ Visited set is shared across all targets — no wasted re-traversal.
+    ✗ Python recursion limit (~1000) blows up on deep dep chains.
     ✗ Cycle detection needs 3-color DFS (WHITE/GRAY/BLACK).
     Complexity: O(V + E).
 
-  APPROACH B — two-pass, per-target BFS + Kahn's  (see: dependencies_of_targets_brute)
-    Pass 1: For each target, BFS its deps into a fresh visited set. Union.
-    Pass 2: Kahn's topo sort restricted to the union.
-
-    ✓ Iterative — no recursion limit.
-    ✓ Cycle detection free from Kahn's.
-    ✗ Pass 1 re-walks shared subgraphs across targets.
-    Complexity: O(k*(V + E)) + O(V + E) where k = len(targets).
-
-  APPROACH C — two-pass, multi-source BFS + Kahn's  (see: dependencies_of_targets)
+  APPROACH B — two-pass, multi-source BFS + Kahn's  (see: dependencies_of_targets)
     Pass 1: ONE BFS starting from ALL targets simultaneously, sharing a
             single `reachable` set. Each node enqueued at most once.
-    Pass 2: Same Kahn's as B.
+    Pass 2: Kahn's topo sort restricted to `reachable`.
 
-    ✓ Every advantage of B, without the k-fold waste.
+    ✓ Iterative — no recursion limit.
+    ✓ Cycle detection free from Kahn's (len(order) != len(reachable)).
+    ✓ Same shared-visited efficiency as approach A.
     Complexity: O(V + E) total.
 
 Narration template:
-    "I'd start with recursive post-order DFS — clean and one-pass. But two
-     concerns: Python's recursion limit on deep chains, and cycle detection
-     is finicky (3-color). Let me switch to iterative Kahn's — that gives
-     cycle detection for free. First pass finds the reachable subgraph
-     from the targets, second pass topo-sorts it. One optimization: instead
-     of a fresh BFS per target, one multi-source BFS with a shared visited
-     set — same work regardless of overlap."
+    "The most natural first version is a recursive post-order DFS from each
+     target with a shared visited set — one pass gets both reachability and
+     topo order (post-order emission). Two concerns for production though:
+     Python's recursion limit on deep chains, and cycle detection needs
+     3-color DFS which is easy to get wrong. So I'll rewrite iteratively
+     as two passes — multi-source BFS to find the reachable subgraph, then
+     Kahn's for the topo sort. Kahn's gives cycle detection for free."
 
 ───────────────────────────────────────────────────────────────────────────
 STEP 3 — MENTAL MODEL
@@ -113,9 +125,8 @@ the graph backwards.
 
 COMPLEXITY
 ----------
-Q1 brute:      O(k*(V+E)) reachability + O(V+E) topo = O(k*(V+E))
-Q1 optimized:  O(V + E)
-Q2:            O(V + E)
+Q1:  O(V + E)   (both approach A and approach B)
+Q2:  O(V + E)
 ═══════════════════════════════════════════════════════════════════════════
 """
 
@@ -130,119 +141,27 @@ class Task:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
-# Q1 APPROACH B (brute force): per-target BFS + Kahn's topo sort
-# ═══════════════════════════════════════════════════════════════════════════
-
-def dependencies_of_targets_brute(all_tasks: list[Task], targets: list[str]) -> list[str]:
-    """APPROACH B — the natural first version to code in an interview.
-
-    Intuition:
-        Two questions, two passes.
-        Q1: "Which tasks matter?"   → BFS from each target, union the results.
-        Q2: "In what order?"        → Kahn's topo sort on that subgraph.
-
-    Why not just Kahn's on all_tasks?
-        Kahn's would happily topo-sort the entire task universe, including
-        unrelated islands (tasks no target depends on). We'd have to filter
-        those out at the end — and filtering requires the reachability info
-        anyway. So we compute reachability first and prune upfront.
-
-    Why not optimal?
-        Pass 1 uses a fresh visited set per target. If F and G both depend
-        on D, D's whole subtree gets walked twice. See `dependencies_of_targets`
-        below for the fix (shared visited set).
-
-    Complexity: O(k*(V+E)) reachability + O(V+E) topo, where k = |targets|.
-    """
-    by_id: dict[str, Task] = {t.id: t for t in all_tasks}
-    target_set: set[str] = set(targets)
-
-    # Defensive: catch bad input at the boundary. Cheap to check, hard to debug otherwise.
-    for tgt in targets:
-        if tgt not in by_id:
-            raise KeyError(f"target {tgt!r} not found in all_tasks")
-
-    # ─── PASS 1: Reachability (per-target BFS, union results) ──────────
-    # WHY: We must know which tasks the targets transitively depend on so
-    # we can (a) prune the input for pass 2 and (b) exclude unrelated
-    # tasks from the final output.
-    #
-    # WHY per-target (not multi-source): This is the "naive" version — for
-    # each target, we run a full BFS with a fresh `per_target_seen` set.
-    # Then we union everything into `reachable`. Wasteful when targets
-    # share deps, but very easy to reason about.
-    reachable: set[str] = set()
-    for tgt in targets:
-        per_target_seen: set[str] = set()
-        queue: deque[str] = deque()
-        # Seed with target's *direct* deps — not the target itself, since
-        # we want to exclude targets from the output.
-        for dep in by_id[tgt].dependencies:
-            if dep not in per_target_seen:
-                per_target_seen.add(dep)
-                queue.append(dep)
-        while queue:
-            node = queue.popleft()
-            for dep in by_id[node].dependencies:
-                if dep not in per_target_seen:
-                    per_target_seen.add(dep)
-                    queue.append(dep)
-        reachable |= per_target_seen
-
-    # ─── PASS 2: Kahn's topological sort restricted to `reachable` ─────
-    # WHY Kahn's over recursive DFS: (1) iterative → no Python stack
-    # limit; (2) built-in cycle detection via `len(order) != len(reachable)`.
-    #
-    # Edge convention: dep → dependent (so a dep is emitted before what
-    # depends on it). in_degree[X] = "how many deps X has that are still
-    # unprocessed." When in_degree[X] == 0, X's deps are all done → emit X.
-    reverse_adj: dict[str, list[str]] = defaultdict(list)
-    in_degree: dict[str, int] = {node: 0 for node in reachable}
-    for node in reachable:
-        for dep in by_id[node].dependencies:
-            if dep in reachable:  # (redundant given BFS invariant, kept for clarity)
-                reverse_adj[dep].append(node)
-                in_degree[node] += 1
-
-    queue = deque(n for n, d in in_degree.items() if d == 0)
-    order: list[str] = []
-    while queue:
-        node = queue.popleft()
-        order.append(node)
-        for dependent in reverse_adj[node]:
-            in_degree[dependent] -= 1
-            if in_degree[dependent] == 0:
-                queue.append(dependent)
-
-    # WHY this check: if a cycle exists, some nodes never reach in_degree
-    # 0, so they're never emitted. len(order) < len(reachable) is the tell.
-    if len(order) != len(reachable):
-        raise ValueError("cycle detected in dependency graph")
-
-    # ─── PASS 3 (trivial): filter out targets from the output ──────────
-    # WHY: The problem asks for "extra work needed before the targets."
-    # Targets in `reachable` (when one target depends on another) must be
-    # dropped here. Confirm this framing with the interviewer upfront.
-    return [n for n in order if n not in target_set]
-
-
-# ═══════════════════════════════════════════════════════════════════════════
-# Q1 APPROACH C (optimized): multi-source BFS + Kahn's topo sort
+# Q1 APPROACH B (production): multi-source BFS + Kahn's topo sort
 # ═══════════════════════════════════════════════════════════════════════════
 
 def dependencies_of_targets(all_tasks: list[Task], targets: list[str]) -> list[str]:
-    """APPROACH C — the optimization to converge on if you have time.
+    """APPROACH B — iterative two-pass version. What to write for production.
 
-    The ONE key insight vs. brute:
-        Instead of running a fresh BFS per target, seed a single BFS queue
-        with the direct deps of EVERY target upfront and share ONE visited
-        set (`reachable`) across the whole traversal. This turns k separate
-        BFSes into one multi-source BFS. Any node reachable from multiple
-        targets gets processed exactly once.
+    Motivation vs. the naive recursive DFS (approach A in the top docstring):
+        Approach A is fine for scratch code but has two issues in real use:
+          - Python's recursion limit (~1000) crashes on deep dep chains.
+          - Cycle detection in a recursive DFS needs 3-color marking
+            (WHITE/GRAY/BLACK), which is easy to get subtly wrong.
+        Rewriting iteratively as two passes fixes both — and Kahn's gives
+        us cycle detection for free (len(order) != len(reachable)).
 
-    Pass 2 (Kahn's) and pass 3 (filter) are byte-identical to brute — the
-    only diff is pass 1. That's the "diff between naive and optimized" you
-    can point at during the interview.
+    Mental model — SCOPE DOWN then ORDER:
+        Pass 1: Multi-source BFS builds `reachable`, the induced subgraph
+                of tasks the targets transitively depend on. `reachable`
+                doubles as the BFS visited set — shared across all targets,
+                so overlapping subgraphs are walked exactly once.
+        Pass 2: Kahn's topological sort restricted to `reachable`.
+        Pass 3: Drop targets from the final list (per problem framing).
 
     Complexity: O(V + E) total.
     """
@@ -282,7 +201,7 @@ def dependencies_of_targets(all_tasks: list[Task], targets: list[str]) -> list[s
                 queue.append(dep)
 
     # ─── PASS 2: Kahn's topological sort restricted to `reachable` ─────
-    # Identical to brute. Kahn's gives us:
+    # Kahn's gives us:
     #   (1) a valid topo order (deps before dependents), and
     #   (2) cycle detection for free.
     reverse_adj: dict[str, list[str]] = defaultdict(list)
@@ -452,9 +371,9 @@ def _validate_topo(output: list[str], tasks_by_id: dict[str, Task], expected: li
 
 if __name__ == "__main__":
     # Fixture-driven demo. Cases live in test_fixtures.json alongside this
-    # file. The runner loads the fixture, executes each case against all
-    # three Q1 variants (brute, optimized, include) and Q2, and validates
-    # results by (a) set equality vs expected, (b) topological validity.
+    # file. The runner loads the fixture, executes each case against both
+    # Q1 variants (exclude, include) and Q2, and validates results by
+    # (a) set equality vs expected, (b) topological validity.
     #
     # Topological order is NOT unique — if A, B, C all have no deps, any
     # order among them is valid. That's why validation checks content +
@@ -486,9 +405,8 @@ if __name__ == "__main__":
                 print(f"   notes: {case['notes']}")
 
             for label, fn, expected in [
-                ("exclude (brute)", dependencies_of_targets_brute, case["expected_exclude"]),
-                ("exclude (opt)  ", dependencies_of_targets,       case["expected_exclude"]),
-                ("include        ", dependencies_of_targets_include, case["expected_include"]),
+                ("exclude", dependencies_of_targets,         case["expected_exclude"]),
+                ("include", dependencies_of_targets_include, case["expected_include"]),
             ]:
                 actual = fn(tasks, targets)
                 status = _validate_topo(actual, tasks_by_id, expected)

--- a/company-tags/vanta/task_dependency_test.py
+++ b/company-tags/vanta/task_dependency_test.py
@@ -1,0 +1,144 @@
+"""
+Tests for task_dependency.py.
+
+Run:  python -m pytest company-tags/vanta/task_dependency_test.py -v
+   OR python  company-tags/vanta/task_dependency_test.py     (uses stdlib unittest)
+"""
+
+import unittest
+
+from task_dependency import Task, ancestors_of_target, dependencies_of_targets
+
+
+def is_topo_order(order: list[str], edges: dict[str, list[str]]) -> bool:
+    """edges: dep -> list of dependents. Return True iff every dep appears
+    before its dependent in `order` (restricted to the ids in `order`)."""
+    idx = {node: i for i, node in enumerate(order)}
+    for dep, dependents in edges.items():
+        if dep not in idx:
+            continue
+        for dependent in dependents:
+            if dependent in idx and idx[dep] >= idx[dependent]:
+                return False
+    return True
+
+
+class TestDependenciesOfTargets(unittest.TestCase):
+    def small_graph(self):
+        # F → {D, E}   D → {A, B, C}   E → {}   A,B,C → {}
+        return [
+            Task("A"),
+            Task("B"),
+            Task("C"),
+            Task("D", ["A", "B", "C"]),
+            Task("E"),
+            Task("F", ["D", "E"]),
+        ]
+
+    def test_single_target_all_deps(self):
+        tasks = self.small_graph()
+        result = dependencies_of_targets(tasks, ["F"])
+        self.assertEqual(set(result), {"A", "B", "C", "D", "E"})
+        self.assertNotIn("F", result)  # target itself excluded
+        edges = {"A": ["D"], "B": ["D"], "C": ["D"], "D": ["F"], "E": ["F"]}
+        self.assertTrue(is_topo_order(result, edges))
+
+    def test_multiple_targets_dedup(self):
+        tasks = self.small_graph()
+        # D and E share nothing with each other, but both are targets
+        result = dependencies_of_targets(tasks, ["D", "E"])
+        # D's deps = {A, B, C}; E has no deps
+        self.assertEqual(set(result), {"A", "B", "C"})
+        # targets themselves excluded
+        self.assertNotIn("D", result)
+        self.assertNotIn("E", result)
+
+    def test_overlapping_targets(self):
+        tasks = self.small_graph()
+        # F's deps include D + D's deps + E; D is itself a target
+        # Expected: dedup, targets excluded → {A, B, C, E}
+        result = dependencies_of_targets(tasks, ["F", "D"])
+        self.assertEqual(set(result), {"A", "B", "C", "E"})
+        self.assertNotIn("F", result)
+        self.assertNotIn("D", result)
+
+    def test_target_with_no_deps(self):
+        tasks = self.small_graph()
+        self.assertEqual(dependencies_of_targets(tasks, ["A"]), [])
+        self.assertEqual(dependencies_of_targets(tasks, ["A", "B", "C"]), [])
+
+    def test_empty_targets(self):
+        tasks = self.small_graph()
+        self.assertEqual(dependencies_of_targets(tasks, []), [])
+
+    def test_diamond_dedup(self):
+        # A → B, A → C, B → D, C → D  (D is deepest; A depends on B,C)
+        # deps of [A] should be {B, C, D}, D appears once
+        tasks = [
+            Task("D"),
+            Task("B", ["D"]),
+            Task("C", ["D"]),
+            Task("A", ["B", "C"]),
+        ]
+        result = dependencies_of_targets(tasks, ["A"])
+        self.assertEqual(set(result), {"B", "C", "D"})
+        self.assertEqual(len(result), 3)  # dedup
+        # D must come before B and C
+        self.assertLess(result.index("D"), result.index("B"))
+        self.assertLess(result.index("D"), result.index("C"))
+
+    def test_unknown_target_raises(self):
+        tasks = self.small_graph()
+        with self.assertRaises(KeyError):
+            dependencies_of_targets(tasks, ["ZZZ"])
+
+    def test_cycle_raises(self):
+        # X → Y, Y → X  (cycle)
+        tasks = [Task("X", ["Y"]), Task("Y", ["X"]), Task("Z", ["X"])]
+        with self.assertRaises(ValueError):
+            dependencies_of_targets(tasks, ["Z"])
+
+
+class TestAncestorsOfTarget(unittest.TestCase):
+    def small_graph(self):
+        return [
+            Task("A"),
+            Task("B"),
+            Task("C"),
+            Task("D", ["A", "B", "C"]),
+            Task("E"),
+            Task("F", ["D", "E"]),
+        ]
+
+    def test_leaf_has_ancestors(self):
+        # A is depended on by D; D is depended on by F
+        result = ancestors_of_target(self.small_graph(), "A")
+        self.assertEqual(set(result), {"D", "F"})
+        self.assertNotIn("A", result)
+
+    def test_shallow_ancestor(self):
+        # D is depended on by F only
+        self.assertEqual(set(ancestors_of_target(self.small_graph(), "D")), {"F"})
+
+    def test_no_ancestors(self):
+        # F is not depended on by anything
+        self.assertEqual(ancestors_of_target(self.small_graph(), "F"), [])
+
+    def test_unknown_target_raises(self):
+        with self.assertRaises(KeyError):
+            ancestors_of_target(self.small_graph(), "ZZZ")
+
+    def test_multiple_ancestor_paths(self):
+        # A → B, A → C, B → D, C → D
+        # ancestors of D = {B, C, A}  (A reaches D through both B and C, should dedup)
+        tasks = [
+            Task("D"),
+            Task("B", ["D"]),
+            Task("C", ["D"]),
+            Task("A", ["B", "C"]),
+        ]
+        self.assertEqual(set(ancestors_of_target(tasks, "D")), {"A", "B", "C"})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/company-tags/vanta/test_fixtures.json
+++ b/company-tags/vanta/test_fixtures.json
@@ -1,0 +1,206 @@
+{
+  "_comment": "Test fixtures for task_dependency.py. Each graph defines a set of Tasks and a list of Q1/Q2 test cases. Expected outputs are given as SETS (order-agnostic) because topological order isn't unique — the runner validates content equality AND topo order validity separately.",
+
+  "graphs": [
+    {
+      "name": "original",
+      "description": "F depends on D and E. D depends on A, B, C. A, B, C, E are leaves.",
+      "ascii_art": [
+        "  A ──┐",
+        "  B ──┤─→ D ─→ F",
+        "  C ──┘       ↑",
+        "         E ───┘"
+      ],
+      "tasks": [
+        {"id": "A"},
+        {"id": "B"},
+        {"id": "C"},
+        {"id": "D", "deps": ["A", "B", "C"]},
+        {"id": "E"},
+        {"id": "F", "deps": ["D", "E"]}
+      ],
+      "q1_cases": [
+        {
+          "targets": ["F"],
+          "expected_exclude": ["A", "B", "C", "D", "E"],
+          "expected_include": ["A", "B", "C", "D", "E", "F"],
+          "notes": "single target, multi-level deps"
+        },
+        {
+          "targets": ["D"],
+          "expected_exclude": ["A", "B", "C"],
+          "expected_include": ["A", "B", "C", "D"],
+          "notes": "single target, one-level deps"
+        },
+        {
+          "targets": ["E"],
+          "expected_exclude": [],
+          "expected_include": ["E"],
+          "notes": "leaf target — nothing to depend on"
+        },
+        {
+          "targets": ["A"],
+          "expected_exclude": [],
+          "expected_include": ["A"],
+          "notes": "leaf target — same as E"
+        },
+        {
+          "targets": ["F", "D"],
+          "expected_exclude": ["A", "B", "C", "E"],
+          "expected_include": ["A", "B", "C", "D", "E", "F"],
+          "notes": "D is a target that F depends on — D is pulled into reachable but filtered from exclude output"
+        },
+        {
+          "targets": ["D", "E"],
+          "expected_exclude": ["A", "B", "C"],
+          "expected_include": ["A", "B", "C", "D", "E"],
+          "notes": "two independent targets"
+        }
+      ],
+      "q2_cases": [
+        {"target": "A", "expected_ancestors": ["D", "F"], "notes": "A → D → F"},
+        {"target": "B", "expected_ancestors": ["D", "F"], "notes": "same shape as A"},
+        {"target": "C", "expected_ancestors": ["D", "F"], "notes": "same shape as A"},
+        {"target": "D", "expected_ancestors": ["F"], "notes": "only F depends on D"},
+        {"target": "E", "expected_ancestors": ["F"], "notes": "only F depends on E"},
+        {"target": "F", "expected_ancestors": [], "notes": "nothing depends on F"}
+      ]
+    },
+
+    {
+      "name": "unrelated_islands",
+      "description": "Two disconnected components — party planning + travel planning. Reachability MUST prune the other side.",
+      "ascii_art": [
+        "  shopping ──→ cook_pasta ──┐",
+        "  decorate ─────────────────┤─→ host_party",
+        "  send_invites ─────────────┘",
+        "",
+        "  book_flight ──→ book_hotel ──→ pack_bags       (separate island)"
+      ],
+      "tasks": [
+        {"id": "shopping"},
+        {"id": "cook_pasta", "deps": ["shopping"]},
+        {"id": "decorate"},
+        {"id": "send_invites"},
+        {"id": "host_party", "deps": ["cook_pasta", "decorate", "send_invites"]},
+        {"id": "book_flight"},
+        {"id": "book_hotel", "deps": ["book_flight"]},
+        {"id": "pack_bags", "deps": ["book_hotel"]}
+      ],
+      "q1_cases": [
+        {
+          "targets": ["host_party"],
+          "expected_exclude": ["shopping", "cook_pasta", "decorate", "send_invites"],
+          "expected_include": ["shopping", "cook_pasta", "decorate", "send_invites", "host_party"],
+          "notes": "travel island NEVER appears in output"
+        },
+        {
+          "targets": ["pack_bags"],
+          "expected_exclude": ["book_flight", "book_hotel"],
+          "expected_include": ["book_flight", "book_hotel", "pack_bags"],
+          "notes": "party island NEVER appears in output"
+        },
+        {
+          "targets": ["host_party", "pack_bags"],
+          "expected_exclude": ["shopping", "cook_pasta", "decorate", "send_invites", "book_flight", "book_hotel"],
+          "expected_include": ["shopping", "cook_pasta", "decorate", "send_invites", "book_flight", "book_hotel", "host_party", "pack_bags"],
+          "notes": "targets in different components — output covers both islands"
+        }
+      ],
+      "q2_cases": [
+        {"target": "shopping", "expected_ancestors": ["cook_pasta", "host_party"], "notes": "chain up the party side"},
+        {"target": "book_flight", "expected_ancestors": ["book_hotel", "pack_bags"], "notes": "chain up the travel side"},
+        {"target": "host_party", "expected_ancestors": [], "notes": "top of its component"}
+      ]
+    },
+
+    {
+      "name": "diamond",
+      "description": "A is reachable via two paths (D→B→A and D→C→A). Shared visited set ensures A is walked exactly once.",
+      "ascii_art": [
+        "        A",
+        "       / \\",
+        "      B   C     (B depends on A. C depends on A.)",
+        "       \\ /",
+        "        D       (D depends on B and C.)"
+      ],
+      "tasks": [
+        {"id": "A"},
+        {"id": "B", "deps": ["A"]},
+        {"id": "C", "deps": ["A"]},
+        {"id": "D", "deps": ["B", "C"]}
+      ],
+      "q1_cases": [
+        {
+          "targets": ["D"],
+          "expected_exclude": ["A", "B", "C"],
+          "expected_include": ["A", "B", "C", "D"],
+          "notes": "A appears ONCE despite two paths"
+        },
+        {
+          "targets": ["B", "C"],
+          "expected_exclude": ["A"],
+          "expected_include": ["A", "B", "C"],
+          "notes": "two targets share dep A — multi-source BFS handles this"
+        },
+        {
+          "targets": ["B", "D"],
+          "expected_exclude": ["A", "C"],
+          "expected_include": ["A", "B", "C", "D"],
+          "notes": "B is a target that D depends on — pulled in then filtered from exclude"
+        }
+      ],
+      "q2_cases": [
+        {"target": "A", "expected_ancestors": ["B", "C", "D"], "notes": "A is depended on by B, C directly, and D transitively"},
+        {"target": "B", "expected_ancestors": ["D"], "notes": "only D depends on B"},
+        {"target": "D", "expected_ancestors": [], "notes": "top of graph"}
+      ]
+    },
+
+    {
+      "name": "linear_chain",
+      "description": "5-task linear chain — the only case with a UNIQUE topological order.",
+      "ascii_art": [
+        "  t1 ──→ t2 ──→ t3 ──→ t4 ──→ t5"
+      ],
+      "tasks": [
+        {"id": "t1"},
+        {"id": "t2", "deps": ["t1"]},
+        {"id": "t3", "deps": ["t2"]},
+        {"id": "t4", "deps": ["t3"]},
+        {"id": "t5", "deps": ["t4"]}
+      ],
+      "q1_cases": [
+        {
+          "targets": [],
+          "expected_exclude": [],
+          "expected_include": [],
+          "notes": "empty targets list → empty output"
+        },
+        {
+          "targets": ["t1"],
+          "expected_exclude": [],
+          "expected_include": ["t1"],
+          "notes": "leaf target"
+        },
+        {
+          "targets": ["t5"],
+          "expected_exclude": ["t1", "t2", "t3", "t4"],
+          "expected_include": ["t1", "t2", "t3", "t4", "t5"],
+          "notes": "full chain — output order is fully determined"
+        },
+        {
+          "targets": ["t3", "t5"],
+          "expected_exclude": ["t1", "t2", "t4"],
+          "expected_include": ["t1", "t2", "t3", "t4", "t5"],
+          "notes": "two targets in same chain — t3 filtered in exclude, still needed in include for t4/t5 ordering"
+        }
+      ],
+      "q2_cases": [
+        {"target": "t1", "expected_ancestors": ["t2", "t3", "t4", "t5"], "notes": "everything is downstream"},
+        {"target": "t3", "expected_ancestors": ["t4", "t5"], "notes": "only two nodes downstream"},
+        {"target": "t5", "expected_ancestors": [], "notes": "end of chain"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a `company-tags/vanta/` prep folder based on 1point3acres candidate reports (June 2025–June 2026).

**Immediate focus — phone screen:**
- `phone-screen.md` — format (60min CoderPad), time budget, common bugs, post-mortem template
- `task_dependency.py` + `task_dependency_test.py` — reference solution for the dominant reported problem (Q1 transitive deps of multiple targets in topo order + dedup; Q2 transitive ancestors of a target). **13 tests, all passing.**
- `employee_training.py` + `employee_training_test.py` — reference solution for the backup problem (Q1 single-employee overdue calc; Q2 aggregate employee count + overdue days across a group tree). **11 tests, all passing.**

**Reference material for onsite rounds** (in `onsite/`):
- Round 1 — practical coding with file I/O warmup
- Round 2 — DAU/MAU tracking system design (HLL, event ingestion, multi-tenant)
- Round 3 — scenario behavioral framework + 6 drill scenarios
- Round 4 — HM project deep-dive storyboard
- Round 5 — RAG pipeline for compliance docs (Alireza 9-step, chunking, hybrid retrieval, evals, hallucination mitigation, multi-tenant data isolation)

## Test plan

- [ ] `python3 company-tags/vanta/task_dependency_test.py` — 13 passing
- [ ] `python3 company-tags/vanta/employee_training_test.py` — 11 passing
- [ ] Drill each phone-screen problem cold in a scratch file with a 25-min timer, diff against the reference

## Notes

- Branched off `main` (not the open restructure PR) to keep scope focused.
- Cross-links Round 5 (RAG) to the GenAI MLE track from the other PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)